### PR TITLE
on_tick test

### DIFF
--- a/envoyfilter/src/lib.rs
+++ b/envoyfilter/src/lib.rs
@@ -124,6 +124,16 @@ impl Context for HttpHeaderRoot {}
 
 // RootContext allows the Rust code to reach into the Envoy Config
 impl RootContext for HttpHeaderRoot {
+    fn on_vm_start(&mut self, _vm_configuration_size: usize) -> bool {
+        info!("on_vm_start");
+        self.set_tick_period(Duration::from_secs(5));
+        true
+    }
+
+    fn on_tick(&mut self) {
+        info!("on_tick");
+    }
+
     fn on_configure(&mut self, plugin_configuration_size: usize) -> bool {
         info!(
             "on_configure: plugin_configuration_size is {}",


### PR DESCRIPTION
```
envoyfilter-envoy-1  | [2024-07-17 19:10:08.881][1][info][wasm] [source/extensions/common/wasm/context.cc:1195] wasm log: on_tick
envoyfilter-envoy-1  | [2024-07-17 19:10:08.988][19][info][wasm] [source/extensions/common/wasm/context.cc:1195] wasm log: on_tick
envoyfilter-envoy-1  | [2024-07-17 19:10:08.988][25][info][wasm] [source/extensions/common/wasm/context.cc:1195] wasm log: on_tick
envoyfilter-envoy-1  | [2024-07-17 19:10:08.988][20][info][wasm] [source/extensions/common/wasm/context.cc:1195] wasm log: on_tick
envoyfilter-envoy-1  | [2024-07-17 19:10:08.988][21][info][wasm] [source/extensions/common/wasm/context.cc:1195] wasm log: on_tick
envoyfilter-envoy-1  | [2024-07-17 19:10:08.988][23][info][wasm] [source/extensions/common/wasm/context.cc:1195] wasm log: on_tick
```