### PR TITLE
Delete example code, and move prod code into functional separation

### DIFF
--- a/envoyfilter/src/lib.rs
+++ b/envoyfilter/src/lib.rs
@@ -190,7 +190,7 @@ impl FilterContext {
         }
     }
 
-    fn embedding_request_worker(
+    fn embedding_request_handler(
         &mut self,
         body_size: usize,
         create_embedding_request: CreateEmbeddingRequest,
@@ -288,7 +288,9 @@ impl Context for FilterContext {
             common_types::MessageType::EmbeddingRequest(common_types::EmbeddingRequest {
                 create_embedding_request,
                 prompt_target,
-            }) => self.embedding_request_worker(body_size, create_embedding_request, prompt_target),
+            }) => {
+                self.embedding_request_handler(body_size, create_embedding_request, prompt_target)
+            }
             common_types::MessageType::CreateVectorStorePoints(_) => {
                 self.create_vector_store_points_worker(body_size)
             }


### PR DESCRIPTION
This PR deletes all the previous filter code that served as a working example and only leaves the production code for the Katanemo gateway. The only exception is the stats code.

This refactor also prepares the code to be unit tested by separating functionality into small functions.

I have a subsequent PR that starts investigating mocking proxy_wasm::host_calls. The main problem is that the linker still expects the extern C functions when compiling tests.