### PR TITLE
expose access logs from envoy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ demos/network_copilot/open-webui/
 demos/employee_details_copilot/ollama/models/
 demos/employee_details_copilot_arch/ollama/models/
 demos/network_copilot/ollama/models/
+arch_log/

--- a/demos/function_calling/docker-compose.yaml
+++ b/demos/function_calling/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     volumes:
       - ./generated/envoy.yaml:/etc/envoy/envoy.yaml
       - /etc/ssl/cert.pem:/etc/ssl/cert.pem
+      - ./arch_log:/var/log/
     depends_on:
       config_generator:
         condition: service_completed_successfully

--- a/envoyfilter/envoy.template.yaml
+++ b/envoyfilter/envoy.template.yaml
@@ -16,6 +16,11 @@ static_resources:
               codec_type: AUTO
               scheme_header_transformation:
                 scheme_to_overwrite: https
+              access_log:
+              - name: envoy.access_loggers.file
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                  path: "/var/log/arch_access.log"
               route_config:
                 name: local_routes
                 virtual_hosts:


### PR DESCRIPTION
This will help greatly in debugging connection failures from envoy,

```
➜  function_calling git:(main) ✗ tail -F arch_log/arch_access.log
[2024-09-26T22:50:30.159Z] "POST /v1/chat/completions HTTP/1.1" 503 UF 98 173 3 - "-" "OpenAI/Python 1.46.1" "30dee192-a123-46e0-8236-a45417eaf02d" "bolt:10000" "[2607:7700:0:33:0:1:ac42:f3]:443"
[2024-09-26T22:50:31.077Z] "POST /v1/chat/completions HTTP/1.1" 503 UF 98 173 2 - "-" "OpenAI/Python 1.46.1" "b2519bb7-53fa-47f2-960d-145d050a61f7" "bolt:10000" "[2607:7700:0:33:0:1:ac42:f3]:443"
[2024-09-26T22:50:32.735Z] "POST /v1/chat/completions HTTP/1.1" 503 UF 98 173 2 - "-" "OpenAI/Python 1.46.1" "64c7127e-fe7d-42cf-93b7-af34be1a78d3" "bolt:10000" "[2607:7700:0:33:0:1:ac42:f3]:443"
``