### PR TITLE
changes prometheus target to arch so that data collection works

### DIFF
--- a/demos/function_calling/prometheus/prometheus.yaml
+++ b/demos/function_calling/prometheus/prometheus.yaml
@@ -18,6 +18,6 @@ scrape_configs:
   scheme: http
   static_configs:
   - targets:
-    - bolt:9901
+    - arch:9901
   params:
     format: ['prometheus']


### PR DESCRIPTION
Stats were not working in function_calling demo due to a naming error while changing name from bolt to arch, this fixes that and now data goes instantly to Grafana again.