### PR TITLE
change default stat_prefix from ingress_http to arch

### DIFF
--- a/arch/envoy.template.yaml
+++ b/arch/envoy.template.yaml
@@ -12,7 +12,7 @@ static_resources:
           - name: envoy.filters.network.http_connection_manager
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-              stat_prefix: arch
+              stat_prefix: arch_ingress_http
               codec_type: AUTO
               scheme_header_transformation:
                 scheme_to_overwrite: https


### PR DESCRIPTION
changes the stat_prefix for http connection manager in envoy.template.yaml from ingress_http to arch.