### PR TITLE
fix embeddings not found bug

### DIFF
--- a/arch/src/stream_context.rs
+++ b/arch/src/stream_context.rs
@@ -208,7 +208,7 @@ impl StreamContext {
                             "embeddings not found for prompt target name: {}",
                             prompt_name
                         );
-                        return (prompt_name.clone(), 0.0);
+                        return (prompt_name.clone(), f64::NAN);
                     }
                 };
 
@@ -219,7 +219,7 @@ impl StreamContext {
                             "description embeddings not found for prompt target name: {}",
                             prompt_name
                         );
-                        return (prompt_name.clone(), 0.0);
+                        return (prompt_name.clone(), f64::NAN);
                     }
                 };
                 let similarity_score_description =

--- a/arch/tests/integration.rs
+++ b/arch/tests/integration.rs
@@ -175,6 +175,8 @@ fn normal_flow(module: &mut Tester, filter_context: i32, http_context: i32) {
         .expect_get_buffer_bytes(Some(BufferType::HttpCallResponseBody))
         .returning(Some(&embeddings_response_buffer))
         .expect_log(Some(LogLevel::Debug), None)
+        .expect_log(Some(LogLevel::Warn), None)
+        .expect_log(Some(LogLevel::Warn), None)
         .expect_log(Some(LogLevel::Debug), None)
         .expect_http_call(
             Some("model_server"),


### PR DESCRIPTION
```
arch-1  | [2024-10-04 20:55:39.661][25][critical][wasm] [source/extensions/common/wasm/context.cc:1204] wasm log http_config: panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/acap-0.3.0/src/coords.rs:75:13:
arch-1  | index out of bounds: the len is 1 but the index is 1
arch-1  | [2024-10-04 20:55:39.664][25][error][wasm] [source/extensions/common/wasm/wasm_vm.cc:38] Function: proxy_on_http_call_response failed: Uncaught RuntimeError: unreachable
arch-1  | Proxy-Wasm plugin in-VM backtrace:
arch-1  |   0:  0x1cfa91 - __rust_start_panic
arch-1  |   1:  0x1cf8be - rust_panic
arch-1  |   2:  0x1cf674 - std::panicking::rust_panic_with_hook::h50e657195af0239c
arch-1  |   3:  0x1ce936 - std::panicking::begin_panic_handler::_$u7b$$u7b$closure$u7d$$u7d$::h0187e6969a85aab0
arch-1  |   4:  0x1ce89d - std::sys_common::backtrace::__rust_end_short_backtrace::h575fb82445d56667
arch-1  |   5:  0x1cf20c - rust_begin_unwind
arch-1  |   6:  0x1dcafb - core::panicking::panic_fmt::ha6764f2272b7fb95
arch-1  |   7:  0x1dcfa8 - core::panicking::panic_bounds_check::h219d719f2d55cbcd
arch-1  |   8:  0x4829a - core::ops::function::impls::_$LT$impl$u20$core..ops..function..FnOnce$LT$A$GT$$u20$for$u20$$RF$mut$u20$F$GT$::call_once::h0d97470666b5ed2b
arch-1  |   9:  0x7dd0e - _$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$alloc..vec..spec_from_iter..SpecFromIter$LT$T$C$I$GT$$GT$::from_iter::h2de54ebc8a48e4a0
```