### PR TITLE
fix pkg_resources error

### DIFF
--- a/arch/tools/setup.py
+++ b/arch/tools/setup.py
@@ -8,10 +8,12 @@ setup(
     packages=find_packages(),
     py_modules = ['cli', 'core', 'targets', 'utils', 'config_generator'],
     include_package_data=True,
+    # Specify to include the docker-compose.yml file
     package_data={
-        '': ['config/docker-compose.yaml', 'config/arch_config_schema.yaml'] #Specify to include the docker-compose.yml file
+        '': ['config/docker-compose.yaml', 'config/arch_config_schema.yaml']
     },
-    install_requires=['pyyaml', 'pydantic', 'click', 'jinja2','pyyaml','jsonschema', 'setuptools'],  # Add dependencies here, e.g., 'PyYAML' for YAML processing
+    # Add dependencies here, e.g., 'PyYAML' for YAML processing
+    install_requires=['pyyaml', 'pydantic', 'click', 'jinja2','pyyaml','jsonschema', 'setuptools'],
     entry_points={
         'console_scripts': [
             'archgw=cli:main',


### PR DESCRIPTION
```
(venv) ➜  bin git:(main) archgw
Traceback (most recent call last):
  File "/Users/adilhafeez/src/intelligent-prompt-gateway/arch/tools/venv/bin/archgw", line 5, in <module>
    from cli import main
  File "/Users/adilhafeez/src/intelligent-prompt-gateway/arch/tools/cli.py", line 2, in <module>
    from core import start_arch, stop_arch
  File "/Users/adilhafeez/src/intelligent-prompt-gateway/arch/tools/core.py", line 4, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```