### PR TITLE
ensure that tracing is optional in arch_config

### DIFF
--- a/arch/envoy.template.yaml
+++ b/arch/envoy.template.yaml
@@ -14,7 +14,7 @@ static_resources:
             - name: envoy.filters.network.http_connection_manager
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                {% if arch_tracing.random_sampling > 0 %}
+                {% if "random_sampling" in arch_tracing and arch_tracing["random_sampling"] > 0 %}
                 generate_request_id: true
                 tracing:
                   provider:
@@ -95,7 +95,7 @@ static_resources:
             - name: envoy.filters.network.http_connection_manager
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                {% if arch_tracing.random_sampling > 0 %}
+                {% if "random_sampling" in arch_tracing and arch_tracing["random_sampling"] > 0 %}
                 generate_request_id: true
                 tracing:
                   provider:
@@ -289,7 +289,7 @@ static_resources:
                       port_value: 11000
                   hostname: arch_internal
 
-{% if arch_tracing.random_sampling > 0 %}
+{% if "random_sampling" in arch_tracing and arch_tracing["random_sampling"] > 0 %}
     - name: opentelemetry_collector
       type: STRICT_DNS
       dns_lookup_family: V4_ONLY


### PR DESCRIPTION
```
archgw-1  | {'api_server': {'name': 'api_server', 'port': 80}}
archgw-1  | updating cluster {'endpoint': 'host.docker.internal:18083', 'connect_timeout': '0.005s'}
archgw-1  | updated clusters {'api_server': {'name': 'api_server', 'port': 18083, 'endpoint': 'host.docker.internal', 'connect_timeout': '0.005s'}}
archgw-1  | Traceback (most recent call last):
archgw-1  |   File "/config/config_generator.py", line 103, in <module>
archgw-1  |     validate_and_render_schema()
archgw-1  |     ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
archgw-1  |   File "/config/config_generator.py", line 80, in validate_and_render_schema
archgw-1  |     rendered = template.render(data)
archgw-1  |   File "/usr/local/lib/python3.13/site-packages/jinja2/environment.py", line 1304, in render
archgw-1  |     self.environment.handle_exception()
archgw-1  |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
archgw-1  |   File "/usr/local/lib/python3.13/site-packages/jinja2/environment.py", line 939, in handle_exception
archgw-1  |     raise rewrite_traceback_stack(source=source)
archgw-1  |   File "envoy.template.yaml", line 17, in top-level template code
archgw-1  |     {% if arch_tracing.random_sampling > 0 %}
archgw-1  |     ^^^^^^^^^
archgw-1  | jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'random_sampling'
```