### PR TITLE
update readme with python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you have following utilities installed before proceeding further,
 
 1. [Docker System](https://docs.docker.com/get-started/get-docker/) (v24)
 2. [Docker compose](https://docs.docker.com/compose/install/) (v2.29)
-3. [Python](https://www.python.org/downloads/) (v3.10)
+3. [Python](https://www.python.org/downloads/) (v3.12)
 4. [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer) (v1.8.3. *Note: only needed for local development*)
 
 


### PR DESCRIPTION
we no longer support 3.10

```
(venv) ➜  intelligent-prompt-gateway git:(main) ✗ archgw build
2024-11-25 15:27:25,559 - cli.main - INFO - Starting archgw cli version: 0.1.0
Building archgw image...
[+] Building 26.8s (30/30) FINISHED                                                                                                                                                                                      docker:desktop-linux
...

Current Python version (3.10.15) is not allowed by the project (>=3.12).
Please change python executable via the "env use" command.
...
```