### PR TITLE
add schema change to use enum in arch_config

### DIFF
--- a/arch/arch_config_schema.yaml
+++ b/arch/arch_config_schema.yaml
@@ -88,6 +88,10 @@ properties:
                 type: string
               type:
                 type: string
+              enum:
+                type: array
+                items:
+                  type: string
             additionalProperties: false
             required:
               - name

--- a/demos/hr_agent/arch_config.yaml
+++ b/demos/hr_agent/arch_config.yaml
@@ -30,7 +30,7 @@ system_prompt: |
 
 prompt_targets:
     - name: workforce
-      description: Get workforce data like headcount and satisfacton levels by region and staffing type
+      description: Get workforce data like headcount and satisfaction levels by region and staffing type
       endpoint:
         name: app_server
         path: /agent/workforce
@@ -39,6 +39,7 @@ prompt_targets:
           type: str
           description: specific category or nature of employment used by an organization like fte, contract and agency
           required: true
+          enum: [fte, contract, agency]
         - name: region
           type: str
           required: true


### PR DESCRIPTION
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/6aae891f-06f8-48fa-9c9a-520633621169">


without this change you'd see following error,

```
2024-11-25 17:32:21,008 - cli.main - INFO - Validating /Users/adilhafeez/src/intelligent-prompt-gateway/demos/hr_agent/arch_config.yaml
Error validating arch_config file: /Users/adilhafeez/src/intelligent-prompt-gateway/demos/hr_agent/arch_config.yaml, error: Additional properties are not allowed ('enum' was unexpected)
2024-11-25 17:32:21,019 - cli.main - INFO - Exiting archgw up: validation failed
```

fixes https://github.com/katanemo/archgw/issues/212