### PR TITLE
Add Langtrace as a supported observability tool

### DIFF
--- a/docs/source/guides/observability/tracing.rst
+++ b/docs/source/guides/observability/tracing.rst
@@ -289,6 +289,51 @@ To send tracing data to `Datadog <https://docs.datadoghq.com/getting_started/tra
 3. **Deploy the Collector**: Run the collector in your environment.
 4. **Verify Traces**: Access the Datadog APM dashboard to view your traces.
 
+Langtrace
+~~~~~~~~~
+
+Langtrace is an observability tool designed specifically for large language models (LLMs). It helps you capture, analyze, and understand how LLMs are used in your applications including those built using Arch.
+
+To send tracing data to `Langtrace <https://docs.langtrace.ai/supported-integrations/llm-tools/arch>`_:
+
+1. **Install Langtrace**: Install the Langtrace SDK.:
+
+   .. code-block:: console
+
+        $ pip install langtrace-python-sdk
+
+2. **Set Environment Variables**: Provide your Langtrace API key.
+
+   .. code-block:: console
+
+        $ export LANGTRACE_API_KEY=<Your-Langtrace-Api-Key>
+
+3. **Trace Requests**: Once you have Langtrace set up, you can start tracing requests.
+
+   Here's an example of how to trace a request using the Langtrace Python SDK:
+
+   .. code-block:: python
+
+      import os
+      from langtrace_python_sdk import langtrace  # Must precede any llm module imports
+      from openai import OpenAI
+
+      langtrace.init(api_key=os.environ['LANGTRACE_API_KEY'])
+
+      client = OpenAI(api_key=os.environ['OPENAI_API_KEY'], base_url="http://localhost:12000/v1")
+
+      response = client.chat.completions.create(
+          model="gpt-4o-mini",
+          messages=[
+              {"role": "system", "content": "You are a helpful assistant"},
+              {"role": "user", "content": "Hello"},
+          ]
+      )
+
+      print(chat_completion.choices[0].message.content)
+
+4. **Verify Traces**: Access the Langtrace dashboard to view your traces.
+
 
 Best Practices
 --------------
@@ -312,6 +357,7 @@ Additional Resources
 - `W3C Trace Context Specification <https://www.w3.org/TR/trace-context/>`_
 - `AWS X-Ray Exporter <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsxrayexporter>`_
 - `Datadog Exporter <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter>`_
+- `Langtrace Documentation <https://docs.langtrace.ai/introduction>`_
 
 .. Note::
    Replace placeholders such as ``<Your-Aws-Region>`` and ``<Your-Datadog-Api-Key>`` with your actual configurations.

--- a/docs/source/guides/observability/tracing.rst
+++ b/docs/source/guides/observability/tracing.rst
@@ -296,19 +296,21 @@ Langtrace is an observability tool designed specifically for large language mode
 
 To send tracing data to `Langtrace <https://docs.langtrace.ai/supported-integrations/llm-tools/arch>`_:
 
-1. **Install Langtrace**: Install the Langtrace SDK.:
+1. **Configure Arch**: Make sure Arch is installed and setup correctly. For more information, refer to the `installation guide <https://github.com/katanemo/archgw?tab=readme-ov-file#prerequisites>`_.
+
+2. **Install Langtrace**: Install the Langtrace SDK.:
 
    .. code-block:: console
 
         $ pip install langtrace-python-sdk
 
-2. **Set Environment Variables**: Provide your Langtrace API key.
+3. **Set Environment Variables**: Provide your Langtrace API key.
 
    .. code-block:: console
 
         $ export LANGTRACE_API_KEY=<Your-Langtrace-Api-Key>
 
-3. **Trace Requests**: Once you have Langtrace set up, you can start tracing requests.
+4. **Trace Requests**: Once you have Langtrace set up, you can start tracing requests.
 
    Here's an example of how to trace a request using the Langtrace Python SDK:
 
@@ -332,7 +334,7 @@ To send tracing data to `Langtrace <https://docs.langtrace.ai/supported-integrat
 
       print(chat_completion.choices[0].message.content)
 
-4. **Verify Traces**: Access the Langtrace dashboard to view your traces.
+5. **Verify Traces**: Access the Langtrace dashboard to view your traces.
 
 
 Best Practices


### PR DESCRIPTION
This PR adds a new section to the Arch documentation, under the Observability -> Tracing section, to describe the integration with Langtrace, an observability tool specifically designed for large language models (LLMs).

This section includes:

- Introduction to Langtrace: A brief overview of Langtrace and its capabilities.
- Integration steps: Clear instructions on how to integrate Langtrace with Arch, including installation and tracing requests.
- Example code: A Python code snippet demonstrating how to trace requests using the Langtrace SDK.

Below is a screenshot of what a sample request looks like on the Langtrace dashboard:

![arch-img](https://github.com/user-attachments/assets/5cd513f9-499b-4bba-a9f6-5f75f0076d48)
