### PR TITLE
Infer port from protocol if port is not specified and add ability to override hostname in clusters def

### DIFF
--- a/arch/arch_config_schema.yaml
+++ b/arch/arch_config_schema.yaml
@@ -33,6 +33,8 @@ properties:
             enum:
               - http
               - https
+          http_host:
+            type: string
         additionalProperties: false
         required:
           - endpoint
@@ -66,6 +68,8 @@ properties:
           enum:
             - http
             - https
+        http_host:
+          type: string
       additionalProperties: false
       required:
         - name

--- a/arch/envoy.template.yaml
+++ b/arch/envoy.template.yaml
@@ -537,7 +537,11 @@ static_resources:
                     socket_address:
                       address: {{ cluster.endpoint }}
                       port_value: {{ cluster.port }}
+                  {% if cluster.http_host %}
+                  hostname: {{ cluster.http_host }}
+                  {% else %}
                   hostname: {{ cluster.endpoint }}
+                  {% endif %}
       {% if cluster.protocol == "https" %}
       transport_socket:
         name: envoy.transport_sockets.tls
@@ -566,7 +570,11 @@ static_resources:
                     socket_address:
                       address: {{ local_llm_provider.endpoint }}
                       port_value: {{ local_llm_provider.port }}
+                  {% if local_llm_provider.http_host %}
+                  hostname: {{ local_llm_provider.http_host }}
+                  {% else %}
                   hostname: {{ local_llm_provider.endpoint }}
+                  {% endif %}
       {% if local_llm_provider.protocol == "https" %}
       transport_socket:
         name: envoy.transport_sockets.tls

--- a/demos/currency_exchange/arch_config.yaml
+++ b/demos/currency_exchange/arch_config.yaml
@@ -44,7 +44,7 @@ prompt_targets:
 
 endpoints:
   frankfurther_api:
-    endpoint: api.frankfurter.dev:443
+    endpoint: api.frankfurter.dev
     protocol: https
 
 tracing:


### PR DESCRIPTION
If port is not specified in endpoint then port will be inferred from protocol. For example in following arch_config we didn't specify port but the arch gateway inferred port 443 from protocol def,

arch_config.yaml
```
...
endpoints:
  frankfurther_api:
    endpoint: api.frankfurter.dev
    protocol: https
...
```

envoy.yaml
```
...
    - name: frankfurther_api
      connect_timeout: 5s
      type: LOGICAL_DNS
      dns_lookup_family: V4_ONLY
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: frankfurther_api
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: api.frankfurter.dev
                      port_value: 443

                  hostname: api.frankfurter.dev
...
```