### PR TITLE
fix: add --type=container to docker inspect to prevent Podman conflicts

### DIFF
--- a/arch/tools/cli/docker_cli.py
+++ b/arch/tools/cli/docker_cli.py
@@ -11,7 +11,7 @@ log = getLogger(__name__)
 
 def docker_container_status(container: str) -> str:
     result = subprocess.run(
-        ["docker", "inspect", container], capture_output=True, text=True, check=False
+        ["docker", "inspect", "--type=container", container], capture_output=True, text=True, check=False
     )
     if result.returncode != 0:
         return "not found"

--- a/arch/tools/cli/docker_cli.py
+++ b/arch/tools/cli/docker_cli.py
@@ -11,7 +11,10 @@ log = getLogger(__name__)
 
 def docker_container_status(container: str) -> str:
     result = subprocess.run(
-        ["docker", "inspect", "--type=container", container], capture_output=True, text=True, check=False
+        ["docker", "inspect", "--type=container", container],
+        capture_output=True,
+        text=True,
+        check=False,
     )
     if result.returncode != 0:
         return "not found"


### PR DESCRIPTION
Adding `--type=container` ensures `docker inspect` targets containers specifically, preventing conflicts with images in Podman.

Related discussion: https://github.com/katanemo/archgw/issues/417#issuecomment-2682369098