### PR TITLE
publish docker release images

### DIFF
--- a/.github/workflows/docker-push-main.yml
+++ b/.github/workflows/docker-push-main.yml
@@ -1,0 +1,97 @@
+name: Publish docker image (latest)
+
+env:
+  DOCKER_IMAGE: katanemo/archgw
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Build ARM64 image on native ARM64 runner
+  build-arm64:
+    runs-on: [linux-arm64]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=raw,value=latest  # Force the tag to be "latest"
+
+      - name: Build and Push ARM64 Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./arch/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-arm64
+
+  # Build AMD64 image on GitHub's AMD64 runner
+  build-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=raw,value=latest  # Force the tag to be "latest"
+
+      - name: Build and Push AMD64 Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./arch/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-amd64
+
+
+  # Combine ARM64 and AMD64 images into a multi-arch manifest
+  create-manifest:
+    runs-on: ubuntu-latest
+    needs: [build-arm64, build-amd64]  # Wait for both builds
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=raw,value=latest  # Force the tag to be "latest"
+
+      - name: Create Multi-Arch Manifest
+        run: |
+          # Combine the architecture-specific images into a "latest" manifest
+          docker buildx imagetools create -t ${{ steps.meta.outputs.tags }} \
+            ${{ env.DOCKER_IMAGE }}:latest-arm64 \
+            ${{ env.DOCKER_IMAGE }}:latest-amd64

--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -1,12 +1,8 @@
-name: Publish Docker image
-
-env:
-  DOCKER_IMAGE: katanemo/archgw
+name: Publish docker image (release)
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   # Build ARM64 image on native ARM64 runner
@@ -27,8 +23,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_IMAGE }}
-          tags: |
-            type=raw,value=latest  # Force the tag to be "latest"
 
       - name: Build and Push ARM64 Image
         uses: docker/build-push-action@v5
@@ -57,8 +51,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_IMAGE }}
-          tags: |
-            type=raw,value=latest  # Force the tag to be "latest"
 
       - name: Build and Push AMD64 Image
         uses: docker/build-push-action@v5
@@ -86,12 +78,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_IMAGE }}
-          tags: |
-            type=raw,value=latest  # Force the tag to be "latest"
 
       - name: Create Multi-Arch Manifest
         run: |
-          # Combine the architecture-specific images into a "latest" manifest
+          # Combine the architecture-specific images into a single manifest
           docker buildx imagetools create -t ${{ steps.meta.outputs.tags }} \
-            ${{ env.DOCKER_IMAGE }}:latest-arm64 \
-            ${{ env.DOCKER_IMAGE }}:latest-amd64
+            ${{ env.DOCKER_IMAGE }}:arm64 \
+            ${{ env.DOCKER_IMAGE }}:amd64

--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -3,7 +3,6 @@ name: Publish docker image (release)
 on:
   release:
     types: [published]
-  push:
 
 jobs:
   # Build ARM64 image on native ARM64 runner

--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -3,6 +3,7 @@ name: Publish docker image (release)
 on:
   release:
     types: [published]
+  push:
 
 jobs:
   # Build ARM64 image on native ARM64 runner


### PR DESCRIPTION
Right now we publish docker images for all commits that go on main. This change will start publishing images for releases. This will keep a publish history of our docker images by release version. Eventually we will update our CLI's to use these pin'ed versions whenever we publish a new release.

This is the view of repository right now,

https://hub.docker.com/repository/docker/katanemo/archgw/general
<img width="173" alt="image" src="https://github.com/user-attachments/assets/7bfa7282-c718-457a-993b-67edde0c1369" />


After this change we should see per arch and multi-arch docker image for each release. For example for release 0.2.3 you'd see following images,

- 0.2.3-amd64
- 0.2.3-arm64
- 0.2.3