### PR TITLE
start using base_url in place of endpoint

### DIFF
--- a/arch/arch_config_schema.yaml
+++ b/arch/arch_config_schema.yaml
@@ -80,6 +80,8 @@ properties:
           type: boolean
         endpoint:
           type: string
+        base_url:
+          type: string
         protocol:
           type: string
           enum:

--- a/arch/arch_config_schema.yaml
+++ b/arch/arch_config_schema.yaml
@@ -62,7 +62,7 @@ properties:
       properties:
         name:
           type: string
-        # this field is deprecated, use provider_interface instead
+        # provider field is deprecated, use provider_interface instead
         provider:
           type: string
           enum:
@@ -78,6 +78,7 @@ properties:
           type: string
         default:
           type: boolean
+        # endpoint field is deprecated, use base_url instead
         endpoint:
           type: string
         base_url:

--- a/demos/use_cases/llm_routing/arch_config.yaml
+++ b/demos/use_cases/llm_routing/arch_config.yaml
@@ -33,8 +33,7 @@ llm_providers:
     access_key: $DEEPSEEK_API_KEY
     provider_interface: openai
     model: deepseek-reasoner
-    endpoint: api.deepseek.com
-    protocol: https
+    base_url: https://api.deepseek.com/
 
 tracing:
   random_sampling: 100


### PR DESCRIPTION
before,

```
  - name: deepseek
    access_key: $DEEPSEEK_API_KEY
    provider_interface: openai
    model: deepseek-reasoner
    endpoint: api.deepseek.com
    protocol: https
    port: 443
```

after

```
  - name: deepseek
    access_key: $DEEPSEEK_API_KEY
    provider_interface: openai
    model: deepseek-reasoner
    base_url: https://api.deepseek.com/
```

