### PR TITLE
Add support for json based content types in Message

### DIFF
--- a/arch/envoy.template.yaml
+++ b/arch/envoy.template.yaml
@@ -625,7 +625,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: 0.0.0.0
+                      address: host.docker.internal
                       port_value: 9091
                   hostname: localhost
 

--- a/arch/envoy.template.yaml
+++ b/arch/envoy.template.yaml
@@ -728,7 +728,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: host.docker.internal
+                      address: 0.0.0.0
                       port_value: 9091
                   hostname: localhost
 

--- a/arch/tools/cli/config_generator.py
+++ b/arch/tools/cli/config_generator.py
@@ -80,7 +80,17 @@ def validate_and_render_schema():
     llms_with_endpoint = []
 
     updated_llm_providers = []
+    llm_provider_name_set = set()
     for llm_provider in config_yaml["llm_providers"]:
+        if llm_provider.get("name") in llm_provider_name_set:
+            raise Exception(
+                f"Duplicate llm_provider name {llm_provider.get('name')}, please provide unique name for each llm_provider"
+            )
+        if llm_provider.get("name") is None:
+            raise Exception(
+                f"llm_provider name is required, please provide name for llm_provider"
+            )
+        llm_provider_name_set.add(llm_provider.get("name"))
         provider = None
         if llm_provider.get("provider") and llm_provider.get("provider_interface"):
             raise Exception(

--- a/arch/tools/cli/docker_cli.py
+++ b/arch/tools/cli/docker_cli.py
@@ -52,15 +52,12 @@ def docker_start_archgw_detached(
     port_mappings = [
         f"{prompt_gateway_port}:{prompt_gateway_port}",
         f"{llm_gateway_port}:{llm_gateway_port}",
-        # expose llm gateway as well without tracing support
-        f"{llm_gateway_port + 1}:{llm_gateway_port + 1}",
         "9901:19901",
     ]
     port_mappings_args = [item for port in port_mappings for item in ("-p", port)]
 
     volume_mappings = [
         f"{arch_config_file}:/app/arch_config.yaml:ro",
-        # "/Users/adilhafeez/src/intelligent-prompt-gateway/crates/target/wasm32-wasip1/release:/etc/envoy/proxy-wasm-plugins:ro",
     ]
     volume_mappings_args = [
         item for volume in volume_mappings for item in ("-v", volume)

--- a/arch/tools/cli/docker_cli.py
+++ b/arch/tools/cli/docker_cli.py
@@ -52,6 +52,8 @@ def docker_start_archgw_detached(
     port_mappings = [
         f"{prompt_gateway_port}:{prompt_gateway_port}",
         f"{llm_gateway_port}:{llm_gateway_port}",
+        # expose llm gateway as well without tracing support
+        f"{llm_gateway_port + 1}:{llm_gateway_port + 1}",
         "9901:19901",
     ]
     port_mappings_args = [item for port in port_mappings for item in ("-p", port)]

--- a/crates/brightstaff/src/handlers/chat_completions.rs
+++ b/crates/brightstaff/src/handlers/chat_completions.rs
@@ -9,10 +9,11 @@ use http_body_util::{BodyExt, Full, StreamBody};
 use hyper::body::Frame;
 use hyper::header::{self};
 use hyper::{Request, Response, StatusCode};
+use serde_json::Value;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::router::llm_router::RouterService;
 
@@ -30,19 +31,23 @@ pub async fn chat_completions(
     let mut request_headers = request.headers().clone();
 
     let chat_request_bytes = request.collect().await?.to_bytes();
+
     let chat_completion_request: ChatCompletionsRequest =
         match serde_json::from_slice(&chat_request_bytes) {
             Ok(request) => request,
             Err(err) => {
+                let v: Value = serde_json::from_slice(&chat_request_bytes).unwrap();
                 let err_msg = format!("Failed to parse request body: {}", err);
+                warn!("{}", err_msg);
+                warn!("request body: {}", v.to_string());
                 let mut bad_request = Response::new(full(err_msg));
                 *bad_request.status_mut() = StatusCode::BAD_REQUEST;
                 return Ok(bad_request);
             }
         };
 
-    info!(
-        "request body received: {}",
+    debug!(
+        "request body: {}",
         shorten_string(&serde_json::to_string(&chat_completion_request).unwrap())
     );
 

--- a/crates/brightstaff/src/main.rs
+++ b/crates/brightstaff/src/main.rs
@@ -2,37 +2,26 @@ use brightstaff::handlers::chat_completions::chat_completions;
 use brightstaff::router::llm_router::RouterService;
 use bytes::Bytes;
 use common::configuration::Configuration;
-use common::utils::shorten_string;
 use http_body_util::{combinators::BoxBody, BodyExt, Empty};
 use hyper::body::Incoming;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use opentelemetry::global::BoxedTracer;
 use opentelemetry::trace::FutureExt;
-use opentelemetry::{
-    global,
-    trace::{SpanKind, Tracer},
-    Context,
-};
+use opentelemetry::{global, Context};
 use opentelemetry_http::HeaderExtractor;
 use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::SdkTracerProvider};
 use opentelemetry_stdout::SpanExporter;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use std::{env, fs};
 use tokio::net::TcpListener;
-use tracing::info;
+use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
 
 pub mod router;
 
 const BIND_ADDRESS: &str = "0.0.0.0:9091";
-
-fn get_tracer() -> &'static BoxedTracer {
-    static TRACER: OnceLock<BoxedTracer> = OnceLock::new();
-    TRACER.get_or_init(|| global::tracer("archgw/router"))
-}
 
 // Utility function to extract the context from the incoming request headers
 fn extract_context_from_request(req: &Request<Incoming>) -> Context {
@@ -83,24 +72,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let arch_config = Arc::new(config);
 
-    info!(
+    debug!(
         "arch_config: {:?}",
-        shorten_string(&serde_json::to_string(arch_config.as_ref()).unwrap())
+        &serde_json::to_string(arch_config.as_ref()).unwrap()
     );
 
     let llm_provider_endpoint = env::var("LLM_PROVIDER_ENDPOINT")
         .unwrap_or_else(|_| "http://localhost:12001/v1/chat/completions".to_string());
 
     info!("llm provider endpoint: {}", llm_provider_endpoint);
-    info!("Listening on http://{}", bind_address);
+    info!("listening on http://{}", bind_address);
     let listener = TcpListener::bind(bind_address).await?;
 
-
     // if routing is null then return gpt-4o as model name
-    let model = arch_config.routing.as_ref().map_or_else(
-        || "gpt-4o".to_string(),
-        |routing| routing.model.clone(),
-    );
+    let model = arch_config
+        .routing
+        .as_ref()
+        .map_or_else(|| "gpt-4o".to_string(), |routing| routing.model.clone());
 
     let router_service: Arc<RouterService> = Arc::new(RouterService::new(
         arch_config.llm_providers.clone(),
@@ -119,12 +107,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let service = service_fn(move |req| {
             let router_service = Arc::clone(&router_service);
             let parent_cx = extract_context_from_request(&req);
-            info!("parent_cx: {:?}", parent_cx);
-            let tracer = get_tracer();
-            let _span = tracer
-                .span_builder("request")
-                .with_kind(SpanKind::Server)
-                .start_with_context(tracer, &parent_cx);
             let llm_provider_endpoint = llm_provider_endpoint.clone();
 
             async move {

--- a/crates/brightstaff/src/main.rs
+++ b/crates/brightstaff/src/main.rs
@@ -85,6 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let listener = TcpListener::bind(bind_address).await?;
 
     // if routing is null then return gpt-4o as model name
+    //TODO: fail if routing is null
     let model = arch_config
         .routing
         .as_ref()

--- a/crates/brightstaff/src/router/router_model.rs
+++ b/crates/brightstaff/src/router/router_model.rs
@@ -12,4 +12,5 @@ pub type Result<T> = std::result::Result<T, RoutingModelError>;
 pub trait RouterModel: Send + Sync {
     fn generate_request(&self, messages: &[Message]) -> ChatCompletionsRequest;
     fn parse_response(&self, content: &str) -> Result<Option<String>>;
+    fn get_model_name(&self) -> String;
 }

--- a/crates/common/src/api/hallucination.rs
+++ b/crates/common/src/api/hallucination.rs
@@ -36,22 +36,22 @@ pub fn extract_messages_for_hallucination(messages: &[Message]) -> Vec<String> {
         for message in messages.iter().rev() {
             if let Some(model) = message.model.as_ref() {
                 if !model.starts_with(ARCH_MODEL_PREFIX) {
-                    if let Some(ContentType::Text(content)) = &message.content {
-                        if !content.starts_with(HALLUCINATION_TEMPLATE) {
+                    if let Some(content) = &message.content {
+                        if !content.to_string().starts_with(HALLUCINATION_TEMPLATE) {
                             break;
                         }
                     }
                 }
             }
             if message.role == USER_ROLE {
-                if let Some(ContentType::Text(content)) = &message.content {
-                    user_messages.push(content.clone());
+                if let Some(content) = &message.content {
+                    user_messages.push(content.to_string());
                 }
             }
         }
     } else if let Some(message) = messages.last() {
-        if let Some(ContentType::Text(content)) = &message.content {
-            user_messages.push(content.clone());
+        if let Some(content) = &message.content {
+            user_messages.push(content.to_string());
         }
     }
     user_messages.reverse(); // Reverse to maintain the original order

--- a/crates/common/src/api/hallucination.rs
+++ b/crates/common/src/api/hallucination.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::open_ai::ContentType;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HallucinationClassificationRequest {
     pub prompt: String,
@@ -21,7 +23,7 @@ pub struct HallucinationClassificationResponse {
 
 pub fn extract_messages_for_hallucination(messages: &[Message]) -> Vec<String> {
     let mut arch_assistant = false;
-    let mut user_messages = Vec::new();
+    let mut user_messages: Vec<String> = Vec::new();
     if messages.len() >= 2 {
         let latest_assistant_message = &messages[messages.len() - 2];
         if let Some(model) = latest_assistant_message.model.as_ref() {
@@ -34,7 +36,7 @@ pub fn extract_messages_for_hallucination(messages: &[Message]) -> Vec<String> {
         for message in messages.iter().rev() {
             if let Some(model) = message.model.as_ref() {
                 if !model.starts_with(ARCH_MODEL_PREFIX) {
-                    if let Some(content) = &message.content {
+                    if let Some(ContentType::Text(content)) = &message.content {
                         if !content.starts_with(HALLUCINATION_TEMPLATE) {
                             break;
                         }
@@ -42,13 +44,13 @@ pub fn extract_messages_for_hallucination(messages: &[Message]) -> Vec<String> {
                 }
             }
             if message.role == USER_ROLE {
-                if let Some(content) = &message.content {
+                if let Some(ContentType::Text(content)) = &message.content {
                     user_messages.push(content.clone());
                 }
             }
         }
     } else if let Some(message) = messages.last() {
-        if let Some(content) = &message.content {
+        if let Some(ContentType::Text(content)) = &message.content {
             user_messages.push(content.clone());
         }
     }

--- a/crates/common/src/api/open_ai.rs
+++ b/crates/common/src/api/open_ai.rs
@@ -1,6 +1,7 @@
 use crate::consts::{ARCH_FC_MODEL_NAME, ASSISTANT_ROLE};
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 use serde_yaml::Value;
+use core::panic;
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Display,
@@ -154,12 +155,54 @@ pub struct StreamOptions {
     pub include_usage: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum MultiPartContentType {
+    #[serde(rename = "text")]
+    Text,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MultiPartContent {
+    pub text: Option<String>,
+    #[serde(rename = "type")]
+    pub content_type: MultiPartContentType,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ContentType {
+    Text(String),
+    MultiPart(Vec<MultiPartContent>),
+}
+
+impl Display for ContentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ContentType::Text(text) => write!(f, "{}", text),
+            ContentType::MultiPart(multi_part) => {
+                let text_parts: Vec<String> = multi_part
+                    .iter()
+                    .filter_map(|part| {
+                        if part.content_type == MultiPartContentType::Text {
+                            part.text.clone()
+                        } else {
+                            panic!("Unsupported content type: {:?}", part.content_type);
+                        }
+                    })
+                    .collect();
+                let combined_text = text_parts.join("\n");
+                write!(f, "{}", combined_text)
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub role: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
+    pub content: Option<ContentType>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
@@ -237,7 +280,7 @@ impl ChatCompletionsResponse {
             choices: vec![Choice {
                 message: Message {
                     role: ASSISTANT_ROLE.to_string(),
-                    content: Some(message),
+                    content: Some(ContentType::Text(message)),
                     model: Some(ARCH_FC_MODEL_NAME.to_string()),
                     tool_calls: None,
                     tool_call_id: None,
@@ -378,6 +421,8 @@ pub fn to_server_events(chunks: Vec<ChatCompletionStreamResponse>) -> String {
 
 #[cfg(test)]
 mod test {
+    use crate::api::open_ai::{ChatCompletionsRequest, ContentType, MultiPartContentType};
+
     use super::{ChatCompletionStreamResponseServerEvents, Message};
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
@@ -447,7 +492,9 @@ mod test {
             model: "gpt-3.5-turbo".to_string(),
             messages: vec![Message {
                 role: "user".to_string(),
-                content: Some("What city do you want to know the weather for?".to_string()),
+                content: Some(ContentType::Text(
+                    "What city do you want to know the weather for?".to_string(),
+                )),
                 model: None,
                 tool_calls: None,
                 tool_call_id: None,
@@ -677,4 +724,109 @@ data: [DONE]
             "Hello! How can I assist you today?"
         );
     }
+
+    #[test]
+    fn test_chat_completions_request() {
+        const CHAT_COMPLETIONS_REQUEST: &str = r#"
+{
+  "model": "gpt-3.5-turbo",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What city do you want to know the weather for?"
+    }
+  ]
+}"#;
+
+        let chat_completions_request: ChatCompletionsRequest =
+            serde_json::from_str(CHAT_COMPLETIONS_REQUEST).unwrap();
+        assert_eq!(chat_completions_request.model, "gpt-3.5-turbo");
+        assert_eq!(
+            chat_completions_request.messages[0].content,
+            Some(ContentType::Text(
+                "What city do you want to know the weather for?".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_chat_completions_request_text_type() {
+        const CHAT_COMPLETIONS_REQUEST: &str = r#"
+{
+  "model": "gpt-3.5-turbo",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "What city do you want to know the weather for?"
+        }
+      ]
+    }
+  ]
+}
+"#;
+
+        let chat_completions_request: ChatCompletionsRequest =
+            serde_json::from_str(CHAT_COMPLETIONS_REQUEST).unwrap();
+        assert_eq!(chat_completions_request.model, "gpt-3.5-turbo");
+        if let Some(ContentType::MultiPart(multi_part_content)) =
+            chat_completions_request.messages[0].content.as_ref()
+        {
+            assert_eq!(multi_part_content[0].content_type, MultiPartContentType::Text);
+            assert_eq!(
+                multi_part_content[0].text,
+                Some("What city do you want to know the weather for?".to_string())
+            );
+        } else {
+            panic!("Expected MultiPartContent");
+        }
+    }
+
+    #[test]
+    fn test_chat_completions_request_text_type_array() {
+        const CHAT_COMPLETIONS_REQUEST: &str = r#"
+{
+  "model": "gpt-3.5-turbo",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "What city do you want to know the weather for?"
+        },
+        {
+          "type": "text",
+          "text": "hello world"
+        }
+      ]
+    }
+  ]
+}
+"#;
+
+        let chat_completions_request: ChatCompletionsRequest =
+            serde_json::from_str(CHAT_COMPLETIONS_REQUEST).unwrap();
+        assert_eq!(chat_completions_request.model, "gpt-3.5-turbo");
+        if let Some(ContentType::MultiPart(multi_part_content)) =
+            chat_completions_request.messages[0].content.as_ref()
+        {
+            assert_eq!(multi_part_content.len(), 2);
+            assert_eq!(multi_part_content[0].content_type, MultiPartContentType::Text);
+            assert_eq!(
+                multi_part_content[0].text,
+                Some("What city do you want to know the weather for?".to_string())
+            );
+            assert_eq!(multi_part_content[1].content_type, MultiPartContentType::Text);
+            assert_eq!(
+                multi_part_content[1].text,
+                Some("hello world".to_string())
+            );
+        } else {
+            panic!("Expected MultiPartContent");
+        }
+    }
+
 }

--- a/crates/llm_gateway/src/stream_context.rs
+++ b/crates/llm_gateway/src/stream_context.rs
@@ -1,7 +1,7 @@
 use crate::metrics::Metrics;
 use common::api::open_ai::{
     ChatCompletionStreamResponseServerEvents, ChatCompletionsRequest, ChatCompletionsResponse,
-    Message, StreamOptions,
+    ContentType, Message, StreamOptions,
 };
 use common::configuration::{LlmProvider, LlmProviderType, Overrides};
 use common::consts::{
@@ -384,7 +384,12 @@ impl HttpContext for StreamContext {
             .messages
             .iter()
             .fold(String::new(), |acc, m| {
-                acc + " " + m.content.as_ref().unwrap_or(&String::new())
+                acc + " "
+                    + m.content
+                        .as_ref()
+                        .unwrap_or(&ContentType::Text(String::new()))
+                        .to_string()
+                        .as_str()
             });
         // enforce ratelimits on ingress
         if let Err(e) = self.enforce_ratelimits(&deserialized_body.model, input_tokens_str.as_str())

--- a/crates/prompt_gateway/src/http_context.rs
+++ b/crates/prompt_gateway/src/http_context.rs
@@ -2,6 +2,7 @@ use crate::stream_context::{ResponseHandlerType, StreamCallContext, StreamContex
 use common::{
     api::open_ai::{
         self, ArchState, ChatCompletionStreamResponse, ChatCompletionTool, ChatCompletionsRequest,
+        ContentType,
     },
     consts::{
         ARCH_FC_MODEL_NAME, ARCH_INTERNAL_CLUSTER_NAME, ARCH_ROUTING_HEADER,
@@ -237,22 +238,32 @@ impl HttpContext for StreamContext {
             Duration::from_secs(5),
         );
 
-        let call_context = StreamCallContext {
-            response_handler_type: ResponseHandlerType::ArchFC,
-            user_message: self.user_prompt.as_ref().unwrap().content.clone(),
-            prompt_target_name: None,
-            request_body: self.chat_completions_request.as_ref().unwrap().clone(),
-            similarity_scores: None,
-            upstream_cluster: Some(ARCH_INTERNAL_CLUSTER_NAME.to_string()),
-            upstream_cluster_path: Some("/function_calling".to_string()),
-        };
+        if let Some(ContentType::Text(content)) =
+            self.user_prompt.as_ref().unwrap().content.as_ref()
+        {
+            let call_context = StreamCallContext {
+                response_handler_type: ResponseHandlerType::ArchFC,
+                user_message: Some(content.clone()),
+                prompt_target_name: None,
+                request_body: self.chat_completions_request.as_ref().unwrap().clone(),
+                similarity_scores: None,
+                upstream_cluster: Some(ARCH_INTERNAL_CLUSTER_NAME.to_string()),
+                upstream_cluster_path: Some("/function_calling".to_string()),
+            };
 
-        if let Err(e) = self.http_call(call_args, call_context) {
-            warn!("http_call failed: {:?}", e);
-            self.send_server_error(ServerError::HttpDispatch(e), None);
+            if let Err(e) = self.http_call(call_args, call_context) {
+                warn!("http_call failed: {:?}", e);
+                self.send_server_error(ServerError::HttpDispatch(e), None);
+            }
+        } else {
+            warn!("No content in the last user prompt");
+            self.send_server_error(
+                ServerError::LogicError("No content in the last user prompt".to_string()),
+                None,
+            );
         }
-
         Action::Pause
+
     }
 
     fn on_http_response_headers(&mut self, _num_headers: usize, _end_of_stream: bool) -> Action {

--- a/crates/prompt_gateway/src/http_context.rs
+++ b/crates/prompt_gateway/src/http_context.rs
@@ -2,7 +2,6 @@ use crate::stream_context::{ResponseHandlerType, StreamCallContext, StreamContex
 use common::{
     api::open_ai::{
         self, ArchState, ChatCompletionStreamResponse, ChatCompletionTool, ChatCompletionsRequest,
-        ContentType,
     },
     consts::{
         ARCH_FC_MODEL_NAME, ARCH_INTERNAL_CLUSTER_NAME, ARCH_ROUTING_HEADER,
@@ -238,12 +237,12 @@ impl HttpContext for StreamContext {
             Duration::from_secs(5),
         );
 
-        if let Some(ContentType::Text(content)) =
+        if let Some(content) =
             self.user_prompt.as_ref().unwrap().content.as_ref()
         {
             let call_context = StreamCallContext {
                 response_handler_type: ResponseHandlerType::ArchFC,
-                user_message: Some(content.clone()),
+                user_message: Some(content.to_string()),
                 prompt_target_name: None,
                 request_body: self.chat_completions_request.as_ref().unwrap().clone(),
                 similarity_scores: None,

--- a/crates/prompt_gateway/tests/integration.rs
+++ b/crates/prompt_gateway/tests/integration.rs
@@ -1,5 +1,5 @@
 use common::api::open_ai::{
-    ChatCompletionsResponse, Choice, FunctionCallDetail, Message, ToolCall, ToolType, Usage,
+    ChatCompletionsResponse, Choice, ContentType, FunctionCallDetail, Message, ToolCall, ToolType, Usage
 };
 use common::configuration::Configuration;
 use http::StatusCode;
@@ -431,7 +431,7 @@ fn prompt_gateway_request_to_llm_gateway() {
             index: Some(0),
             message: Message {
                 role: "assistant".to_string(),
-                content: Some("hello from fake llm gateway".to_string()),
+                content: Some(ContentType::Text("hello from fake llm gateway".to_string())),
                 model: None,
                 tool_calls: None,
                 tool_call_id: None,

--- a/demos/use_cases/preference_based_routing/arch_config.yaml
+++ b/demos/use_cases/preference_based_routing/arch_config.yaml
@@ -14,13 +14,13 @@ llm_providers:
 
   - name: archgw-v1-router-model
     provider_interface: openai
-    model: cotran2/llama-1b-4-26
-    base_url: http://35.192.87.187:8000/v1
+    model: cotran2/llama-4-epoch
+    base_url: http://34.46.85.85:8000/v1
 
-  - name: gpt-4o-mini
+  - name: gpt-4o
     provider_interface: openai
     access_key: $OPENAI_API_KEY
-    model: gpt-4o-mini
+    model: gpt-4o
     default: true
 
   - name: gpt-4o
@@ -34,6 +34,18 @@ llm_providers:
     access_key: $OPENAI_API_KEY
     model: o4-mini
     usage: Requesting topic ideas specifically related to personal finance and budgeting.
+
+  - name: code_generation
+    provider_interface: openai
+    access_key: $OPENAI_API_KEY
+    model: gpt-4.1
+    usage: Generating new code snippets, functions, or boilerplate based on user prompts or requirements
+
+  - name: code_understanding
+    provider_interface: openai
+    access_key: $OPENAI_API_KEY
+    model: gpt-4.1
+    usage: understand and explain existing code snippets, functions, or libraries
 
 tracing:
   random_sampling: 100

--- a/demos/use_cases/preference_based_routing/arch_config.yaml
+++ b/demos/use_cases/preference_based_routing/arch_config.yaml
@@ -21,19 +21,12 @@ llm_providers:
     provider_interface: openai
     access_key: $OPENAI_API_KEY
     model: gpt-4o
-    usage: Generating original content such as scripts, articles, or creative materials.
     default: true
-
-  - name: o4-mini
-    provider_interface: openai
-    access_key: $OPENAI_API_KEY
-    model: o4-mini
-    usage: Requesting topic ideas specifically related to personal finance and budgeting.
 
   - name: code_generation
     provider_interface: openai
     access_key: $OPENAI_API_KEY
-    model: gpt-4.1
+    model: gpt-4o
     usage: Generating new code snippets, functions, or boilerplate based on user prompts or requirements
 
   - name: code_understanding

--- a/demos/use_cases/preference_based_routing/arch_config.yaml
+++ b/demos/use_cases/preference_based_routing/arch_config.yaml
@@ -21,13 +21,8 @@ llm_providers:
     provider_interface: openai
     access_key: $OPENAI_API_KEY
     model: gpt-4o
-    default: true
-
-  - name: gpt-4o
-    provider_interface: openai
-    access_key: $OPENAI_API_KEY
-    model: gpt-4o
     usage: Generating original content such as scripts, articles, or creative materials.
+    default: true
 
   - name: o4-mini
     provider_interface: openai

--- a/demos/use_cases/preference_based_routing/hurl_tests/simple.hurl
+++ b/demos/use_cases/preference_based_routing/hurl_tests/simple.hurl
@@ -12,7 +12,7 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 header "content-type" == "application/json"
-jsonpath "$.model" matches /^o4-mini/
+jsonpath "$.model" matches /^gpt-4o/
 jsonpath "$.usage" != null
 jsonpath "$.choices[0].message.content" != null
 jsonpath "$.choices[0].message.role" == "assistant"

--- a/demos/use_cases/preference_based_routing/hurl_tests/simple_stream.hurl
+++ b/demos/use_cases/preference_based_routing/hurl_tests/simple_stream.hurl
@@ -13,4 +13,4 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 header "content-type" matches /text\/event-stream/
-body matches /^data: .*?o4-mini.*?\n/
+body matches /^data: .*?gpt-4o.*?\n/


### PR DESCRIPTION
Adds support for json based content in message struct. For example you can now add text blocks,

```
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "What city do you want to know the weather for?"
        }
      ]
    }
  ]

```

here is another example,

```
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "What city do you want to know the weather for?"
        },
        {
          "type": "text",
          "text": "hello world"
        }
      ]
    }
  ]

```