### PR TITLE
add claude-4 in llm_routing demo

### DIFF
--- a/demos/use_cases/llm_routing/arch_config.yaml
+++ b/demos/use_cases/llm_routing/arch_config.yaml
@@ -29,6 +29,11 @@ llm_providers:
     model: claude-3-7-sonnet-latest
     default: true
 
+  - name: claude-sonnet-4
+    access_key: $ANTHROPY_API_KEY
+    provider_interface: claude
+    model: claude-sonnet-4-0
+
   - name: deepseek
     access_key: $DEEPSEEK_API_KEY
     provider_interface: deepseek


### PR DESCRIPTION
updated llm_routing demo to add claude-4 in list of llm_providers
```
$ curl -XPOST -v localhost:12000/v1/chat/completions -H 'content-type: application/json' -d '{"stream": false, "messages": [{"role": "user","content": "hello"}]}' | jq .
...
{
  "id": "msg_01NnyBz8ijqtZEMiD6cdgzEL",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Hello! How are you doing today? Is there anything I can help you with?"
      }
    }
  ],
  "created": 1748020705,
  "model": "claude-sonnet-4-20250514",
  "object": "chat.completion",
  "usage": {
    "completion_tokens": 20,
    "prompt_tokens": 8,
    "total_tokens": 28
  }
}
```