### PR TITLE
add support for openwebui

### DIFF
--- a/arch/envoy.template.yaml
+++ b/arch/envoy.template.yaml
@@ -728,7 +728,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: host.docker.internal
+                      address: 0.0.0.0
                       port_value: 9091
                   hostname: localhost
 

--- a/arch/envoy.template.yaml
+++ b/arch/envoy.template.yaml
@@ -728,7 +728,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: 0.0.0.0
+                      address: host.docker.internal
                       port_value: 9091
                   hostname: localhost
 

--- a/arch/tools/cli/docker_cli.py
+++ b/arch/tools/cli/docker_cli.py
@@ -52,6 +52,7 @@ def docker_start_archgw_detached(
     port_mappings = [
         f"{prompt_gateway_port}:{prompt_gateway_port}",
         f"{llm_gateway_port}:{llm_gateway_port}",
+        f"{llm_gateway_port+1}:{llm_gateway_port+1}",
         "19901:9901",
     ]
     port_mappings_args = [item for port in port_mappings for item in ("-p", port)]

--- a/crates/brightstaff/src/handlers/mod.rs
+++ b/crates/brightstaff/src/handlers/mod.rs
@@ -1,1 +1,2 @@
 pub mod chat_completions;
+pub mod models;

--- a/crates/brightstaff/src/handlers/models.rs
+++ b/crates/brightstaff/src/handlers/models.rs
@@ -2,7 +2,6 @@ use bytes::Bytes;
 use common::api::open_ai::Models;
 use common::configuration::LlmProvider;
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
-use hyper::body::Body;
 use hyper::{Response, StatusCode};
 use serde_json;
 use std::sync::Arc;
@@ -12,11 +11,6 @@ pub async fn list_models(
 ) -> Response<BoxBody<Bytes, hyper::Error>> {
     let prov = llm_providers.clone();
     let providers = (*prov).clone();
-    let providers = providers
-        .iter()
-        .filter(|provider| provider.name == "gpt-4o-mini")
-        .cloned()
-        .collect::<Vec<_>>();
     let openai_models = Models::from(providers);
 
     match serde_json::to_string(&openai_models) {

--- a/crates/brightstaff/src/handlers/models.rs
+++ b/crates/brightstaff/src/handlers/models.rs
@@ -1,0 +1,46 @@
+use bytes::Bytes;
+use common::api::open_ai::Models;
+use common::configuration::LlmProvider;
+use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use hyper::body::Body;
+use hyper::{Response, StatusCode};
+use serde_json;
+use std::sync::Arc;
+
+pub async fn list_models(
+    llm_providers: Arc<Vec<LlmProvider>>,
+) -> Response<BoxBody<Bytes, hyper::Error>> {
+    let prov = llm_providers.clone();
+    let providers = (*prov).clone();
+    let providers = providers
+        .iter()
+        .filter(|provider| provider.name == "gpt-4o-mini")
+        .cloned()
+        .collect::<Vec<_>>();
+    let openai_models = Models::from(providers);
+
+    match serde_json::to_string(&openai_models) {
+        Ok(json) => {
+            let body = Full::new(Bytes::from(json))
+                .map_err(|never| match never {})
+                .boxed();
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "application/json")
+                .body(body)
+                .unwrap()
+        }
+        Err(_) => {
+            let body = Full::new(Bytes::from_static(
+                b"{\"error\":\"Failed to serialize models\"}",
+            ))
+            .map_err(|never| match never {})
+            .boxed();
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header("Content-Type", "application/json")
+                .body(body)
+                .unwrap()
+        }
+    }
+}

--- a/crates/brightstaff/src/main.rs
+++ b/crates/brightstaff/src/main.rs
@@ -1,4 +1,5 @@
 use brightstaff::handlers::chat_completions::chat_completions;
+use brightstaff::handlers::models::list_models;
 use brightstaff::router::llm_router::RouterService;
 use bytes::Bytes;
 use common::configuration::Configuration;
@@ -72,6 +73,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let arch_config = Arc::new(config);
 
+    let llm_providers = Arc::new(arch_config.llm_providers.clone());
+
     debug!(
         "arch_config: {:?}",
         &serde_json::to_string(arch_config.as_ref()).unwrap()
@@ -104,10 +107,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let router_service = Arc::clone(&router_service);
         let llm_provider_endpoint = llm_provider_endpoint.clone();
 
+        let llm_providers = llm_providers.clone();
         let service = service_fn(move |req| {
             let router_service = Arc::clone(&router_service);
             let parent_cx = extract_context_from_request(&req);
             let llm_provider_endpoint = llm_provider_endpoint.clone();
+            let llm_providers = llm_providers.clone();
 
             async move {
                 match (req.method(), req.uri().path()) {
@@ -115,6 +120,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         chat_completions(req, router_service, llm_provider_endpoint)
                             .with_context(parent_cx)
                             .await
+                    }
+                    (&Method::GET, "/v1/models") => {
+                        Ok(list_models(llm_providers).await)
+                    }
+                    (&Method::OPTIONS, "/v1/models") => {
+                        let mut response = Response::new(empty());
+                        *response.status_mut() = StatusCode::NO_CONTENT;
+                        response.headers_mut().insert(
+                            "Allow",
+                            "GET, OPTIONS".parse().unwrap(),
+                        );
+                        response.headers_mut().insert(
+                            "Access-Control-Allow-Origin",
+                            "*".parse().unwrap(),
+                        );
+                        response.headers_mut().insert(
+                            "Access-Control-Allow-Headers",
+                            "Authorization, Content-Type".parse().unwrap(),
+                        );
+                        response.headers_mut().insert(
+                            "Access-Control-Allow-Methods",
+                            "GET, POST, OPTIONS".parse().unwrap(),
+                        );
+                        response.headers_mut().insert(
+                            "Content-Type",
+                            "application/json".parse().unwrap(),
+                        );
+
+                        Ok(response)
                     }
                     _ => {
                         let mut not_found = Response::new(empty());

--- a/demos/use_cases/llm_routing/arch_config.yaml
+++ b/demos/use_cases/llm_routing/arch_config.yaml
@@ -8,6 +8,7 @@ listeners:
     timeout: 30s
 
 llm_providers:
+
   - name: gpt-4o-mini
     access_key: $OPENAI_API_KEY
     provider_interface: openai
@@ -17,6 +18,7 @@ llm_providers:
     access_key: $OPENAI_API_KEY
     provider_interface: openai
     model: gpt-4o
+    default: true
 
   - name: ministral-3b
     access_key: $MISTRAL_API_KEY
@@ -27,7 +29,6 @@ llm_providers:
     access_key: $ANTHROPY_API_KEY
     provider_interface: claude
     model: claude-3-7-sonnet-latest
-    default: true
 
   - name: claude-sonnet-4
     access_key: $ANTHROPY_API_KEY

--- a/demos/use_cases/llm_routing/docker-compose.yaml
+++ b/demos/use_cases/llm_routing/docker-compose.yaml
@@ -1,17 +1,15 @@
 services:
 
-  chatbot_ui:
-    build:
-      context: ../../shared/chatbot_ui
-      dockerfile: Dockerfile
+
+  open-web-ui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    restart: always
     ports:
-      - "18080:8080"
+      - "8080:8080"
     environment:
-      - CHAT_COMPLETION_ENDPOINT=http://host.docker.internal:12000/v1
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    volumes:
-      - ./arch_config.yaml:/app/arch_config.yaml
+      - DEFAULT_MODEL=gpt-4o-mini
+      - OPENAI_API_KEY=your_secret_key
 
   jaeger:
     build:

--- a/demos/use_cases/llm_routing/docker-compose.yaml
+++ b/demos/use_cases/llm_routing/docker-compose.yaml
@@ -3,13 +3,13 @@ services:
 
   open-web-ui:
     image: ghcr.io/open-webui/open-webui:main
-    container_name: open-webui
     restart: always
     ports:
       - "8080:8080"
     environment:
       - DEFAULT_MODEL=gpt-4o-mini
-      - OPENAI_API_KEY=your_secret_key
+      - ENABLE_OPENAI_API=true
+      - OPENAI_API_BASE_URL=http://host.docker.internal:12000/v1
 
   jaeger:
     build:


### PR DESCRIPTION
This code change adds /v1/models endpoint. This is needed by openwebui to show list of supported models.

Another noticeable change in this PR is to use model name from chat message if we cannot find model name from arch-router.

<img width="857" alt="image" src="https://github.com/user-attachments/assets/8aa4ba27-7cc3-4396-9e41-f5800cb84ab3" />
