### PR TITLE
trim conversation if it exceed max limit of what router model can handle

### DIFF
--- a/crates/brightstaff/src/lib.rs
+++ b/crates/brightstaff/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod handlers;
 pub mod router;
+pub mod utils;

--- a/crates/brightstaff/src/router/llm_router.rs
+++ b/crates/brightstaff/src/router/llm_router.rs
@@ -4,7 +4,6 @@ use common::{
     api::open_ai::{ChatCompletionsResponse, ContentType, Message},
     configuration::LlmProvider,
     consts::ARCH_PROVIDER_HINT_HEADER,
-    tokenizer::TiktokenTokenizer,
 };
 use hyper::header;
 use thiserror::Error;
@@ -70,7 +69,6 @@ impl RouterService {
             llm_providers_with_usage_yaml.clone(),
             routing_model_name.clone(),
             router_model_v1::MAX_TOKEN_LEN,
-            Box::new(TiktokenTokenizer {}),
         ));
 
         RouterService {

--- a/crates/brightstaff/src/router/llm_router.rs
+++ b/crates/brightstaff/src/router/llm_router.rs
@@ -4,10 +4,13 @@ use common::{
     api::open_ai::{ChatCompletionsResponse, ContentType, Message},
     configuration::LlmProvider,
     consts::ARCH_PROVIDER_HINT_HEADER,
+    tokenizer::TiktokenTokenizer,
 };
 use hyper::header;
 use thiserror::Error;
 use tracing::{debug, info, warn};
+
+use crate::router::router_model_v1::{self};
 
 use super::router_model::RouterModel;
 
@@ -63,9 +66,11 @@ impl RouterService {
             llm_providers_with_usage_yaml.replace("\n", "\\n")
         );
 
-        let router_model = Arc::new(super::router_model_v1::RouterModelV1::new(
+        let router_model = Arc::new(router_model_v1::RouterModelV1::new(
             llm_providers_with_usage_yaml.clone(),
             routing_model_name.clone(),
+            router_model_v1::MAX_TOKEN_LEN,
+            Box::new(TiktokenTokenizer {}),
         ));
 
         RouterService {

--- a/crates/brightstaff/src/router/router_model_v1.rs
+++ b/crates/brightstaff/src/router/router_model_v1.rs
@@ -1,11 +1,14 @@
 use common::{
     api::open_ai::{ChatCompletionsRequest, ContentType, Message},
     consts::{SYSTEM_ROLE, USER_ROLE},
+    tokenizer::Tokenizer,
 };
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use super::router_model::{RouterModel, RoutingModelError};
 
+pub const MAX_TOKEN_LEN: usize = 2048; // Default max token length for the routing model
 pub const ARCH_ROUTER_V1_SYSTEM_PROMPT: &str = r#"
 You are a helpful assistant designed to find the best suited route.
 You are provided with route description within <routes></routes> XML tags:
@@ -28,17 +31,24 @@ Based on your analysis, provide your response in the following JSON formats if y
 "#;
 
 pub type Result<T> = std::result::Result<T, RoutingModelError>;
-
 pub struct RouterModelV1 {
     llm_providers_with_usage_yaml: String,
     routing_model: String,
+    max_token_length: usize,
+    tokenizer: Box<dyn Tokenizer + Send + Sync>,
 }
-
 impl RouterModelV1 {
-    pub fn new(llm_providers_with_usage_yaml: String, routing_model: String) -> Self {
+    pub fn new(
+        llm_providers_with_usage_yaml: String,
+        routing_model: String,
+        max_token_length: usize,
+        tokenizer: Box<dyn Tokenizer + Send + Sync>,
+    ) -> Self {
         RouterModelV1 {
             llm_providers_with_usage_yaml,
             routing_model,
+            max_token_length,
+            tokenizer,
         }
     }
 }
@@ -50,24 +60,45 @@ struct LlmRouterResponse {
 
 impl RouterModel for RouterModelV1 {
     fn generate_request(&self, messages: &[Message]) -> ChatCompletionsRequest {
-        let messages_str = messages
+        let mut messages_vec = messages
             .iter()
             .filter(|m| m.role != SYSTEM_ROLE)
             .map(|m| {
                 let content_json_str = serde_json::to_string(&m.content).unwrap_or_default();
                 format!("{}: {}", m.role, content_json_str)
             })
-            .collect::<Vec<String>>()
-            .join("\n");
+            .collect::<Vec<String>>();
 
-        let message = ARCH_ROUTER_V1_SYSTEM_PROMPT
-            .replace("{routes}", &self.llm_providers_with_usage_yaml)
-            .replace("{conversation}", messages_str.as_str());
+        let mut messages_content: String;
+
+        loop {
+            messages_content = ARCH_ROUTER_V1_SYSTEM_PROMPT
+                .replace("{routes}", &self.llm_providers_with_usage_yaml)
+                .replace("{conversation}", messages_vec.join("\n").as_str());
+
+            let token_count = self
+                .tokenizer
+                .token_count(&messages_content, &self.routing_model)
+                .unwrap_or(0);
+            if token_count <= self.max_token_length || messages_vec.len() <= 2 {
+                if messages_vec.len() <= 2 {
+                    debug!("RouterModelV1: conversation is too short, using remaining messages",)
+                }
+                break;
+            }
+            debug!(
+                "RouterModelV1: token count {} exceeds max token length {}, truncating conversation",
+                token_count,
+                self.max_token_length
+            );
+            // trim top two elements from the conversation
+            messages_vec = messages_vec.into_iter().skip(2).collect::<Vec<String>>();
+        }
 
         ChatCompletionsRequest {
             model: self.routing_model.clone(),
             messages: vec![Message {
-                content: Some(ContentType::Text(message)),
+                content: Some(ContentType::Text(messages_content)),
                 role: USER_ROLE.to_string(),
                 model: None,
                 tool_calls: None,
@@ -135,7 +166,10 @@ impl std::fmt::Debug for dyn RouterModel {
 
 #[cfg(test)]
 mod tests {
+    use crate::utils::tracing::init_tracer;
+
     use super::*;
+    use common::tokenizer::TiktokenTokenizer;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -166,7 +200,12 @@ user: "seattle"
 
         let routes_yaml = "route1: description1\nroute2: description2";
         let routing_model = "test-model".to_string();
-        let router = RouterModelV1::new(routes_yaml.to_string(), routing_model.clone());
+        let router = RouterModelV1::new(
+            routes_yaml.to_string(),
+            routing_model.clone(),
+            usize::MAX,
+            Box::new(TiktokenTokenizer {}),
+        );
 
         let messages = vec![
             Message {
@@ -201,56 +240,217 @@ user: "seattle"
 
         let prompt = req.messages[0].content.as_ref().unwrap();
 
-        println!("Prompt: {}", prompt);
+        assert_eq!(expected_prompt, prompt.to_string());
+    }
+
+    #[test]
+    fn test_conversation_exceed_token_count() {
+        let _tracer = init_tracer();
+        let expected_prompt = r#"
+You are a helpful assistant designed to find the best suited route.
+You are provided with route description within <routes></routes> XML tags:
+<routes>
+route1: description1
+route2: description2
+</routes>
+
+Your task is to decide which route is best suit with user intent on the conversation in <conversation></conversation> XML tags.  Follow the instruction:
+1. If the latest intent from user is irrelevant, response with empty route {"route": ""}.
+2. If the user request is full fill and user thank or ending the conversation , response with empty route {"route": ""}.
+3. Understand user latest intent and find the best match route in <routes></routes> xml tags.
+
+Based on your analysis, provide your response in the following JSON formats if you decide to match any route:
+{"route": "route_name"}
+
+
+<conversation>
+user: "I want to book a flight."
+assistant: "Sure, where would you like to go?"
+user: "seattle"
+</conversation>
+"#;
+
+        let routes_yaml = "route1: description1\nroute2: description2";
+        let routing_model = "test-model".to_string();
+        let router = RouterModelV1::new(
+            routes_yaml.to_string(),
+            routing_model.clone(),
+            210,
+            Box::new(TiktokenTokenizer {}),
+        );
+
+        let messages = vec![
+            Message {
+                role: "system".to_string(),
+                content: Some(ContentType::Text(
+                    "You are a helpful assistant.".to_string(),
+                )),
+                ..Default::default()
+            },
+            Message {
+                role: "user".to_string(),
+                content: Some(ContentType::Text("Hi".to_string())),
+                ..Default::default()
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: Some(ContentType::Text("Hello! How can I assist you".to_string())),
+                ..Default::default()
+            },
+            Message {
+                role: "user".to_string(),
+                content: Some(ContentType::Text("I want to book a flight.".to_string())),
+                ..Default::default()
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: Some(ContentType::Text(
+                    "Sure, where would you like to go?".to_string(),
+                )),
+                ..Default::default()
+            },
+            Message {
+                role: "user".to_string(),
+                content: Some(ContentType::Text("seattle".to_string())),
+                ..Default::default()
+            },
+        ];
+
+        let req = router.generate_request(&messages);
+
+        let prompt = req.messages[0].content.as_ref().unwrap();
 
         assert_eq!(expected_prompt, prompt.to_string());
     }
-}
 
-#[test]
-fn test_parse_response() {
-    let router = RouterModelV1::new(
-        "route1: description1\nroute2: description2".to_string(),
-        "test-model".to_string(),
-    );
+    #[test]
+    fn test_conversation_exceed_token_count_large_single_message() {
+        let _tracer = init_tracer();
+        let expected_prompt = r#"
+You are a helpful assistant designed to find the best suited route.
+You are provided with route description within <routes></routes> XML tags:
+<routes>
+route1: description1
+route2: description2
+</routes>
 
-    // Case 1: Valid JSON with non-empty route
-    let input = r#"{"route": "route1"}"#;
-    let result = router.parse_response(input).unwrap();
-    assert_eq!(result, Some("route1".to_string()));
+Your task is to decide which route is best suit with user intent on the conversation in <conversation></conversation> XML tags.  Follow the instruction:
+1. If the latest intent from user is irrelevant, response with empty route {"route": ""}.
+2. If the user request is full fill and user thank or ending the conversation , response with empty route {"route": ""}.
+3. Understand user latest intent and find the best match route in <routes></routes> xml tags.
 
-    // Case 2: Valid JSON with empty route
-    let input = r#"{"route": ""}"#;
-    let result = router.parse_response(input).unwrap();
-    assert_eq!(result, None);
+Based on your analysis, provide your response in the following JSON formats if you decide to match any route:
+{"route": "route_name"}
 
-    // Case 3: Valid JSON with null route
-    let input = r#"{"route": null}"#;
-    let result = router.parse_response(input).unwrap();
-    assert_eq!(result, None);
 
-    // Case 4: JSON missing route field
-    let input = r#"{}"#;
-    let result = router.parse_response(input).unwrap();
-    assert_eq!(result, None);
+<conversation>
+user: "Seatte, WA. But I also need to know about the weather there, and if there are any good restaurants nearby, and what the best time to visit is, and also if there are any events happening in the city."
+</conversation>
+"#;
 
-    // Case 4.1: empty string
-    let input = r#""#;
-    let result = router.parse_response(input).unwrap();
-    assert_eq!(result, None);
+        let routes_yaml = "route1: description1\nroute2: description2";
+        let routing_model = "test-model".to_string();
+        let router = RouterModelV1::new(
+            routes_yaml.to_string(),
+            routing_model.clone(),
+            210,
+            Box::new(TiktokenTokenizer {}),
+        );
 
-    // Case 5: Malformed JSON
-    let input = r#"{"route": "route1""#; // missing closing }
-    let result = router.parse_response(input);
-    assert!(result.is_err());
+        let messages = vec![
+            Message {
+                role: "system".to_string(),
+                content: Some(ContentType::Text(
+                    "You are a helpful assistant.".to_string(),
+                )),
+                ..Default::default()
+            },
+            Message {
+                role: "user".to_string(),
+                content: Some(ContentType::Text("Hi".to_string())),
+                ..Default::default()
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: Some(ContentType::Text("Hello! How can I assist you".to_string())),
+                ..Default::default()
+            },
+            Message {
+                role: "user".to_string(),
+                content: Some(ContentType::Text("I want to book a flight.".to_string())),
+                ..Default::default()
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: Some(ContentType::Text(
+                    "Sure, where would you like to go?".to_string(),
+                )),
+                ..Default::default()
+            },
+            Message {
+                role: "user".to_string(),
+                content: Some(ContentType::Text("Seatte, WA. But I also need to know about the weather there, \
+                                                 and if there are any good restaurants nearby, and what the \
+                                                 best time to visit is, and also if there are any events \
+                                                 happening in the city.".to_string())),
+                ..Default::default()
+            },
+        ];
 
-    // Case 6: Single quotes and \n in JSON
-    let input = "{'route': 'route2'}\\n";
-    let result = router.parse_response(input).unwrap();
-    assert_eq!(result, Some("route2".to_string()));
+        let req = router.generate_request(&messages);
 
-    // Case 7: Code block marker
-    let input = "```json\n{\"route\": \"route1\"}\n```";
-    let result = router.parse_response(input).unwrap();
-    assert_eq!(result, Some("route1".to_string()));
+        let prompt = req.messages[0].content.as_ref().unwrap();
+
+        assert_eq!(expected_prompt, prompt.to_string());
+    }
+
+    #[test]
+    fn test_parse_response() {
+        let router = RouterModelV1::new(
+            "route1: description1\nroute2: description2".to_string(),
+            "test-model".to_string(),
+            2000,
+            Box::new(TiktokenTokenizer {}),
+        );
+
+        // Case 1: Valid JSON with non-empty route
+        let input = r#"{"route": "route1"}"#;
+        let result = router.parse_response(input).unwrap();
+        assert_eq!(result, Some("route1".to_string()));
+
+        // Case 2: Valid JSON with empty route
+        let input = r#"{"route": ""}"#;
+        let result = router.parse_response(input).unwrap();
+        assert_eq!(result, None);
+
+        // Case 3: Valid JSON with null route
+        let input = r#"{"route": null}"#;
+        let result = router.parse_response(input).unwrap();
+        assert_eq!(result, None);
+
+        // Case 4: JSON missing route field
+        let input = r#"{}"#;
+        let result = router.parse_response(input).unwrap();
+        assert_eq!(result, None);
+
+        // Case 4.1: empty string
+        let input = r#""#;
+        let result = router.parse_response(input).unwrap();
+        assert_eq!(result, None);
+
+        // Case 5: Malformed JSON
+        let input = r#"{"route": "route1""#; // missing closing }
+        let result = router.parse_response(input);
+        assert!(result.is_err());
+
+        // Case 6: Single quotes and \n in JSON
+        let input = "{'route': 'route2'}\\n";
+        let result = router.parse_response(input).unwrap();
+        assert_eq!(result, Some("route2".to_string()));
+
+        // Case 7: Code block marker
+        let input = "```json\n{\"route\": \"route1\"}\n```";
+        let result = router.parse_response(input).unwrap();
+        assert_eq!(result, Some("route1".to_string()));
+    }
 }

--- a/crates/brightstaff/src/utils/mod.rs
+++ b/crates/brightstaff/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod tracing;

--- a/crates/brightstaff/src/utils/tracing.rs
+++ b/crates/brightstaff/src/utils/tracing.rs
@@ -1,0 +1,29 @@
+use std::sync::OnceLock;
+
+use opentelemetry::global;
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::SdkTracerProvider};
+use opentelemetry_stdout::SpanExporter;
+use tracing_subscriber::EnvFilter;
+
+static INIT_LOGGER: OnceLock<SdkTracerProvider> = OnceLock::new();
+
+pub fn init_tracer() -> &'static SdkTracerProvider {
+    INIT_LOGGER.get_or_init(|| {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        // Install stdout exporter pipeline to be able to retrieve the collected spans.
+        // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces.
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(SpanExporter::default())
+            .build();
+
+        global::set_tracer_provider(provider.clone());
+
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+            )
+            .init();
+
+        provider
+    })
+}

--- a/crates/common/src/tokenizer.rs
+++ b/crates/common/src/tokenizer.rs
@@ -1,18 +1,5 @@
 use log::debug;
 
-pub trait Tokenizer {
-    /// Returns the number of tokens in the given text.
-    fn token_count(&self, text: &str, model_name: &str) -> Result<usize, String>;
-}
-
-pub struct TiktokenTokenizer {}
-
-impl Tokenizer for TiktokenTokenizer {
-    fn token_count(&self, text: &str, model_name: &str) -> Result<usize, String> {
-        token_count(model_name, text)
-    }
-}
-
 #[allow(dead_code)]
 pub fn token_count(model_name: &str, text: &str) -> Result<usize, String> {
     debug!("getting token count model={}", model_name);

--- a/crates/common/src/tokenizer.rs
+++ b/crates/common/src/tokenizer.rs
@@ -1,5 +1,18 @@
 use log::debug;
 
+pub trait Tokenizer {
+    /// Returns the number of tokens in the given text.
+    fn token_count(&self, text: &str, model_name: &str) -> Result<usize, String>;
+}
+
+pub struct TiktokenTokenizer {}
+
+impl Tokenizer for TiktokenTokenizer {
+    fn token_count(&self, text: &str, model_name: &str) -> Result<usize, String> {
+        token_count(model_name, text)
+    }
+}
+
 #[allow(dead_code)]
 pub fn token_count(model_name: &str, text: &str) -> Result<usize, String> {
     debug!("getting token count model={}", model_name);


### PR DESCRIPTION
In this code change trimming happens where we keep most recent messages and start trimming old conversation until total message token size is below max token size supported by router model.

One exception is that if we are down to single message then we will keep the conversation even if it exceed the max token count.