### PR TITLE
Add handling of list (squence) to prompt gateway, fixes issue #429

### DIFF
--- a/crates/prompt_gateway/src/tools.rs
+++ b/crates/prompt_gateway/src/tools.rs
@@ -12,13 +12,20 @@ pub fn filter_tool_params(tool_params: &Option<HashMap<String, Value>>) -> HashM
         .as_ref()
         .unwrap()
         .iter()
-        .filter(|(_, value)| value.is_number() || value.is_string() || value.is_bool())
+        .filter(|(_, value)| value.is_number() || value.is_string() || value.is_bool() || value.is_sequence())
         .map(|(key, value)| match value {
             Value::Number(n) => (key.clone(), n.to_string()),
             Value::String(s) => (key.clone(), s.clone()),
             Value::Bool(b) => (key.clone(), b.to_string()),
             Value::Null => todo!(),
-            Value::Sequence(_) => todo!(),
+            Value::Sequence(seq) => (
+                key.clone(),
+                seq.iter()
+                    .map(|v| v.as_str().unwrap_or_default())
+                    .collect::<Vec<&str>>()
+                    .join(","),
+            ),
+            _ => (key.clone(), "".to_string()),
             Value::Mapping(_) => todo!(),
             Value::Tagged(_) => todo!(),
         })


### PR DESCRIPTION
fix(prompt_gateway): handle list parameters in function calls

Previously, list parameters in function calls were ignored because the `filter_tool_params` function did not handle `serde_yaml::Value::Sequence`.

This resulted in the list parameters not being passed to the target service. This commit adds handling for `Value::Sequence` by converting the sequence of values into a comma-separated string. This allows list parameters to be correctly passed to the target service.