### PR TITLE
archgw_model_server: use sys.executable for uv tool install compat

### DIFF
--- a/model_server/src/cli.py
+++ b/model_server/src/cli.py
@@ -72,7 +72,7 @@ def start_server(port=51000, foreground=False):
     if foreground:
         process = subprocess.Popen(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "uvicorn",
                 "src.main:app",
@@ -85,7 +85,7 @@ def start_server(port=51000, foreground=False):
     else:
         process = subprocess.Popen(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "uvicorn",
                 "src.main:app",


### PR DESCRIPTION
If you install `archgw` / `archgw_modelserver` with `uv` (`uv tool install archgw_modelserver` or `uv tool install --editable ./model_server` for local dev), then `python` may not be an executable on the system. `sys.executable` should behave the same way if you're activating a venv, but also play nicely with `uv tool` workflows