### PR TITLE
updating the implementation of /v1/chat/completions to use the generi…

### DIFF
--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -177,6 +177,18 @@ impl Display for LlmProviderType {
     }
 }
 
+impl LlmProviderType {
+    /// Create a ProviderInstance from this LlmProviderType
+    /// This is the main method for stream_context to get provider-specific interfaces
+    pub fn create_provider_instance(&self) -> hermesllm::ProviderInstance {
+        use hermesllm::ProviderInstance;
+
+        // For now, all providers use OpenAI-compatible APIs
+        // TODO: Return specific provider instances when implementing different APIs
+        ProviderInstance::from_name(&self.to_string())
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ModelUsagePreference {
     pub model: String,
@@ -249,6 +261,14 @@ impl Default for LlmProvider {
 impl Display for LlmProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)
+    }
+}
+
+impl LlmProvider {
+    /// Create a ProviderInstance for this LlmProvider
+    /// This is a convenience method that delegates to the provider_interface
+    pub fn create_provider_instance(&self) -> hermesllm::ProviderInstance {
+        self.provider_interface.create_provider_instance()
     }
 }
 

--- a/crates/hermesllm/src/lib.rs
+++ b/crates/hermesllm/src/lib.rs
@@ -5,6 +5,11 @@ pub mod providers;
 pub mod apis;
 pub mod clients;
 
+// Re-export important traits
+pub use providers::traits::*;
+pub use providers::openai::provider::OpenAIProvider;
+pub use providers::provider_enum::ProviderInstance;
+
 
 use std::fmt::Display;
 pub enum Provider {
@@ -30,6 +35,45 @@ impl From<&str> for Provider {
             "claude" => Provider::Claude,
             "github" => Provider::Github,
             _ => panic!("Unknown provider: {}", value),
+        }
+    }
+}
+
+impl Provider {
+    /// Get the API endpoint path for this provider
+    pub fn api_path(&self) -> &'static str {
+        match self {
+            Provider::OpenAI => "/v1/chat/completions",
+            Provider::Groq => "/openai/v1/chat/completions", // Groq maps to OpenAI-compatible endpoint
+            Provider::Gemini => "/v1/models", // TODO: Update with correct Gemini path
+            Provider::Claude => "/v1/messages", // TODO: Update with correct Claude path
+            Provider::Mistral => "/v1/chat/completions", // Mistral uses OpenAI-compatible API
+            Provider::Deepseek => "/v1/chat/completions", // DeepSeek uses OpenAI-compatible API
+            Provider::Arch => "/v1/chat/completions", // Arch gateway endpoint
+            Provider::Github => "/models", // TODO: Update with correct GitHub models path
+        }
+    }
+
+    /// Check if this provider uses OpenAI-compatible API format
+    pub fn uses_openai_format(&self) -> bool {
+        match self {
+            Provider::OpenAI | Provider::Groq | Provider::Mistral | Provider::Deepseek | Provider::Arch => true,
+            Provider::Gemini | Provider::Claude | Provider::Github => false, // These have their own formats
+        }
+    }
+
+    /// Create a provider implementation instance for this provider
+    pub fn create_provider_instance(&self) -> ProviderInstance {
+        match self {
+            Provider::OpenAI => ProviderInstance::OpenAI(OpenAIProvider),
+            Provider::Groq => ProviderInstance::OpenAI(OpenAIProvider), // Groq uses OpenAI-compatible API
+            Provider::Mistral => ProviderInstance::OpenAI(OpenAIProvider), // Mistral uses OpenAI-compatible API
+            Provider::Deepseek => ProviderInstance::OpenAI(OpenAIProvider), // Deepseek uses OpenAI-compatible API
+            Provider::Arch => ProviderInstance::OpenAI(OpenAIProvider), // Arch gateway uses OpenAI-compatible API
+            // TODO: Implement specific providers for these when they have different APIs
+            Provider::Gemini => ProviderInstance::OpenAI(OpenAIProvider), // For now, use OpenAI-compatible
+            Provider::Claude => ProviderInstance::OpenAI(OpenAIProvider), // For now, use OpenAI-compatible
+            Provider::Github => ProviderInstance::OpenAI(OpenAIProvider), // For now, use OpenAI-compatible
         }
     }
 }

--- a/crates/hermesllm/src/providers/mod.rs
+++ b/crates/hermesllm/src/providers/mod.rs
@@ -1,1 +1,3 @@
 pub mod openai;
+pub mod traits;
+pub mod provider_enum;

--- a/crates/hermesllm/src/providers/openai/mod.rs
+++ b/crates/hermesllm/src/providers/openai/mod.rs
@@ -1,2 +1,3 @@
 pub mod builder;
 pub mod types;
+pub mod provider;

--- a/crates/hermesllm/src/providers/openai/provider.rs
+++ b/crates/hermesllm/src/providers/openai/provider.rs
@@ -1,0 +1,171 @@
+//! OpenAI provider interface implementations
+
+use crate::apis::openai::*;
+use crate::providers::traits::*;
+use crate::Provider;
+
+// Simple error type for OpenAI API operations
+#[derive(Debug, thiserror::Error)]
+pub enum OpenAIApiError {
+    #[error("JSON parsing error: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("UTF-8 parsing error: {0}")]
+    Utf8Error(#[from] std::str::Utf8Error),
+    #[error("Invalid streaming data: {0}")]
+    InvalidStreamingData(String),
+    #[error("Request conversion error: {0}")]
+    RequestConversionError(String),
+}
+
+// ============================================================================
+// OpenAI Provider Definition
+// ============================================================================
+
+pub struct OpenAIProvider;
+
+// Create a concrete streaming response type to avoid lifetime issues
+pub struct OpenAIStreamingResponse {
+    lines: Vec<String>,
+    current_index: usize,
+}
+
+impl OpenAIStreamingResponse {
+    fn new(data: String) -> Self {
+        let lines: Vec<String> = data.lines().map(|s| s.to_string()).collect();
+        Self {
+            lines,
+            current_index: 0,
+        }
+    }
+}
+
+impl Iterator for OpenAIStreamingResponse {
+    type Item = Result<ChatCompletionsStreamResponse, OpenAIApiError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.current_index < self.lines.len() {
+            let line = &self.lines[self.current_index];
+            self.current_index += 1;
+
+            if let Some(data) = line.strip_prefix("data: ") {
+                let data = data.trim();
+                if data == "[DONE]" {
+                    return None;
+                }
+
+                if data == r#"{"type": "ping"}"# {
+                    continue; // Skip ping messages
+                }
+
+                return Some(
+                    serde_json::from_str::<ChatCompletionsStreamResponse>(data).map_err(|e| {
+                        OpenAIApiError::InvalidStreamingData(format!("Error parsing: {}, data: {}", e, data))
+                    }),
+                );
+            }
+        }
+        None
+    }
+}
+
+impl ProviderInterface for OpenAIProvider {
+    type Request = ChatCompletionsRequest;
+    type Response = ChatCompletionsResponse;
+    type StreamingResponse = OpenAIStreamingResponse;
+    type Usage = Usage;
+}
+
+// ============================================================================
+// Trait Implementations for OpenAI Types
+// ============================================================================
+
+impl ProviderRequest for ChatCompletionsRequest {
+    type Error = OpenAIApiError;
+
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let s = std::str::from_utf8(bytes)?;
+        Ok(serde_json::from_str(s)?)
+    }
+
+    fn to_provider_bytes(&self, _provider: Provider) -> Result<Vec<u8>, Self::Error> {
+        Ok(serde_json::to_vec(self)?)
+    }
+
+    fn extract_model(&self) -> &str {
+        &self.model
+    }
+
+    fn is_streaming(&self) -> bool {
+        self.stream.unwrap_or_default()
+    }
+
+    fn set_streaming_options(&mut self) {
+        if self.stream_options.is_none() {
+            self.stream_options = Some(StreamOptions {
+                include_usage: Some(true),
+            });
+        }
+    }
+
+    fn extract_messages_text(&self) -> String {
+        self.messages
+            .iter()
+            .fold(String::new(), |acc, m| {
+                acc + " " + &match &m.content {
+                    MessageContent::Text(text) => text.clone(),
+                    MessageContent::Parts(parts) => {
+                        parts.iter().map(|part| match part {
+                            ContentPart::Text { text } => text.clone(),
+                            ContentPart::ImageUrl { .. } => "[Image]".to_string(),
+                        }).collect::<Vec<_>>().join(" ")
+                    }
+                }
+            })
+    }
+}
+
+impl TokenUsage for Usage {
+    fn completion_tokens(&self) -> usize {
+        self.completion_tokens as usize
+    }
+
+    fn prompt_tokens(&self) -> usize {
+        self.prompt_tokens as usize
+    }
+
+    fn total_tokens(&self) -> usize {
+        self.total_tokens as usize
+    }
+}
+
+impl ProviderResponse for ChatCompletionsResponse {
+    type Error = OpenAIApiError;
+    type Usage = Usage;
+
+    fn try_from_bytes(bytes: &[u8], _provider: &Provider) -> Result<Self, Self::Error> {
+        let s = std::str::from_utf8(bytes)?;
+        Ok(serde_json::from_str(s)?)
+    }
+
+    fn usage(&self) -> Option<&Self::Usage> {
+        Some(&self.usage)
+    }
+}
+
+impl StreamChunk for ChatCompletionsStreamResponse {
+    type Usage = Usage;
+
+    fn usage(&self) -> Option<&Self::Usage> {
+        self.usage.as_ref()
+    }
+}
+
+impl StreamingResponse for OpenAIStreamingResponse {
+    type Error = OpenAIApiError;
+    type Chunk = ChatCompletionsStreamResponse;
+
+    fn try_from_bytes(bytes: &[u8], _provider: &Provider) -> Result<Self, Self::Error> {
+        let s = std::str::from_utf8(bytes)?;
+        Ok(OpenAIStreamingResponse::new(s.to_string()))
+    }
+}

--- a/crates/hermesllm/src/providers/provider_enum.rs
+++ b/crates/hermesllm/src/providers/provider_enum.rs
@@ -1,0 +1,67 @@
+use crate::providers::traits::*;
+use crate::providers::openai::provider::{OpenAIProvider, OpenAIStreamingResponse};
+use crate::apis::openai::{ChatCompletionsRequest, ChatCompletionsResponse, Usage};
+
+/// Enum that wraps all possible providers for dynamic dispatch
+pub enum ProviderInstance {
+    OpenAI(OpenAIProvider),
+    // TODO: Add other providers as they are implemented
+    // Anthropic(AnthropicProvider),
+    // Mistral(MistralProvider),
+    // etc.
+}
+
+impl ProviderInstance {
+    /// Creates a provider from a provider name string
+    pub fn from_name(name: &str) -> Self {
+        match name.to_lowercase().as_str() {
+            "openai" | "groq" | "gemini" | "mistral" | "deepseek" | "arch" | "claude" => {
+                ProviderInstance::OpenAI(OpenAIProvider)
+            }
+            // TODO: Add other providers when implemented
+            // "claude" | "anthropic" => ProviderInstance::Anthropic(AnthropicProvider),
+            // "mistral" => ProviderInstance::Mistral(MistralProvider),
+            _ => {
+                // Default to OpenAI for unknown providers
+                ProviderInstance::OpenAI(OpenAIProvider)
+            }
+        }
+    }
+
+    /// Parse request from bytes using the appropriate provider
+    pub fn parse_request(&self, bytes: &[u8]) -> Result<ChatCompletionsRequest, Box<dyn std::error::Error + Send + Sync>> {
+        match self {
+            ProviderInstance::OpenAI(_) => {
+                ChatCompletionsRequest::try_from_bytes(bytes).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            }
+            // TODO: Add other provider cases when implemented
+        }
+    }
+
+    /// Parse response from bytes using the appropriate provider
+    pub fn parse_response(&self, bytes: &[u8], provider: &crate::Provider) -> Result<ChatCompletionsResponse, Box<dyn std::error::Error + Send + Sync>> {
+        match self {
+            ProviderInstance::OpenAI(_) => {
+                ChatCompletionsResponse::try_from_bytes(bytes, provider).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            }
+            // TODO: Add other provider cases when implemented
+        }
+    }
+
+    /// Parse streaming response from bytes using the appropriate provider
+    pub fn parse_streaming_response(&self, bytes: &[u8], provider: &crate::Provider) -> Result<OpenAIStreamingResponse, Box<dyn std::error::Error + Send + Sync>> {
+        match self {
+            ProviderInstance::OpenAI(_) => {
+                OpenAIStreamingResponse::try_from_bytes(bytes, provider).map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            }
+            // TODO: Add other provider cases when implemented
+        }
+    }
+}
+
+impl ProviderInterface for ProviderInstance {
+    type Request = ChatCompletionsRequest;
+    type Response = ChatCompletionsResponse;
+    type StreamingResponse = OpenAIStreamingResponse;
+    type Usage = Usage;
+}

--- a/crates/hermesllm/src/providers/traits.rs
+++ b/crates/hermesllm/src/providers/traits.rs
@@ -1,0 +1,74 @@
+//! Provider traits for generic request/response handling
+//!
+//! This module defines the core traits that enable provider-agnostic
+//! handling of LLM requests and responses in the gateway.
+
+use std::error::Error;
+use crate::Provider;
+
+/// Trait for provider-specific request types
+pub trait ProviderRequest: Sized {
+    type Error: Error + Send + Sync + 'static;
+
+    /// Parse request from raw bytes
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>;
+
+    /// Convert to provider-specific format
+    fn to_provider_bytes(&self, provider: Provider) -> Result<Vec<u8>, Self::Error>;
+
+    /// Extract the model name from the request
+    fn extract_model(&self) -> &str;
+
+    /// Check if this is a streaming request
+    fn is_streaming(&self) -> bool;
+
+    /// Set streaming options (e.g., include_usage)
+    fn set_streaming_options(&mut self);
+
+    /// Extract text content from messages for token counting
+    fn extract_messages_text(&self) -> String;
+}
+
+/// Trait for token usage information
+pub trait TokenUsage {
+    fn completion_tokens(&self) -> usize;
+    fn prompt_tokens(&self) -> usize;
+    fn total_tokens(&self) -> usize;
+}
+
+/// Trait for provider-specific response types
+pub trait ProviderResponse: Sized {
+    type Error: Error + Send + Sync + 'static;
+    type Usage: TokenUsage;
+
+    /// Parse response from raw bytes
+    fn try_from_bytes(bytes: &[u8], provider: &Provider) -> Result<Self, Self::Error>;
+
+    /// Get usage information if available
+    fn usage(&self) -> Option<&Self::Usage>;
+}
+
+/// Trait for streaming response chunks
+pub trait StreamChunk {
+    type Usage: TokenUsage;
+
+    /// Get usage information if available
+    fn usage(&self) -> Option<&Self::Usage>;
+}
+
+/// Trait for streaming response iterators
+pub trait StreamingResponse: Iterator<Item = Result<Self::Chunk, Self::Error>> + Sized {
+    type Error: Error + Send + Sync + 'static;
+    type Chunk: StreamChunk;
+
+    /// Parse streaming response from raw bytes
+    fn try_from_bytes(bytes: &[u8], provider: &Provider) -> Result<Self, Self::Error>;
+}
+
+/// Main provider interface trait
+pub trait ProviderInterface {
+    type Request: ProviderRequest;
+    type Response: ProviderResponse;
+    type StreamingResponse: StreamingResponse;
+    type Usage: TokenUsage;
+}


### PR DESCRIPTION
…c provider interfaces

The primary purpose of this change is to decouple the use of /v1/chat/completions with a ProviderInterface that all Providers implemented to send requests upstream and parse the response. There are several todos

1. Make sure that that the ProviderIntstance and ProviderInterface are reconciled
2. Move all mentions of types.rs in the providers/openai folder with providers/apis/openai.rs
3. Validate and test responses from all upstream LLMs
4. Push path conversion in the ProviderInteface vs. the hardcoded stuff in stream_context.rs
