### PR TITLE
add log_level env var

### DIFF
--- a/cli/planoai/utils.py
+++ b/cli/planoai/utils.py
@@ -7,15 +7,34 @@ import logging
 from planoai.consts import PLANO_DOCKER_NAME
 
 
+# Standard env var for log level across all Plano components
+LOG_LEVEL_ENV = "LOG_LEVEL"
+
+_env_log_level = os.environ.get(LOG_LEVEL_ENV, "info").upper()
+_log_level = getattr(logging, _env_log_level, logging.INFO)
+
 logging.basicConfig(
-    level=logging.INFO,
+    level=_log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 
 
+def set_log_level(level: str):
+    """Set the log level for all loggers. Accepts: debug, info, warn, error."""
+    global _log_level
+    numeric_level = getattr(logging, level.upper(), None)
+    if numeric_level is None:
+        raise ValueError(f"Invalid log level: {level}")
+    _log_level = numeric_level
+    logging.getLogger().setLevel(_log_level)
+    # Update all existing planoai loggers
+    for name in logging.Logger.manager.loggerDict:
+        logging.getLogger(name).setLevel(_log_level)
+
+
 def getLogger(name="cli"):
     logger = logging.getLogger(name)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(_log_level)
     return logger
 
 

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -4,7 +4,7 @@ nodaemon=true
 [program:brightstaff]
 command=sh -c "\
     envsubst < /app/arch_config_rendered.yaml > /app/arch_config_rendered.env_sub.yaml && \
-    RUST_LOG=info \
+    RUST_LOG=${LOG_LEVEL:-info} \
     ARCH_CONFIG_PATH_RENDERED=/app/arch_config_rendered.env_sub.yaml \
     /app/brightstaff 2>&1 | \
     tee /var/log/brightstaff.log | \
@@ -18,8 +18,8 @@ stderr_logfile_maxbytes=0
 command=/bin/sh -c "\
     uv run python -m planoai.config_generator && \
     envsubst < /etc/envoy/envoy.yaml > /etc/envoy.env_sub.yaml && \
-    envoy -c /etc/envoy.env_sub.yaml \
-          --component-log-level wasm:info \
+        envoy -c /etc/envoy.env_sub.yaml \
+            --component-log-level wasm:${LOG_LEVEL:-info} \
           --log-format '[%%Y-%%m-%%d %%T.%%e][%%l] %%v' 2>&1 | \
     tee /var/log/envoy.log | \
     while IFS= read -r line; do echo '[plano_logs]' \"$line\"; done"


### PR DESCRIPTION
add support for changing log level without rebuilding docker image

```
$ LOG_LEVEL=debug planoai up --foreground
...
[brightstaff] [2026-02-09 05:15:48.517][debug] Processing specific provider configuration: openai/gpt-4o-mini    
[brightstaff] [2026-02-09 05:15:48.517][debug] Processing specific provider configuration: arch-function    
[brightstaff] [2026-02-09 05:15:48.517][debug] Processing specific provider configuration: plano-orchestrator    
[brightstaff] [2026-02-09 05:15:48.544][info] Tracing configuration found in arch_config.yaml
...```