### PR TITLE
Update demos to use AnythingLLM and katanemo/plano:latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,8 +117,6 @@ docs/build/
 # Plano - Demos
 demos/function_calling/ollama/models/
 demos/function_calling/ollama/id_ed*
-demos/function_calling/open-webui/
-demos/function_calling/open-webui/
 demos/shared/signoz/data
 
 # Plano - Miscellaneous

--- a/demos/use_cases/http_filter/docker-compose.yaml
+++ b/demos/use_cases/http_filter/docker-compose.yaml
@@ -12,9 +12,7 @@ services:
       - LLM_GATEWAY_ENDPOINT=${LLM_GATEWAY_ENDPOINT:-http://host.docker.internal:12000/v1}
       - OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY environment variable is required but not set}
   plano:
-    build:
-      context: ../../../
-      dockerfile: Dockerfile
+    image: katanemo/plano:latest
     ports:
       - "12000:12000"
       - "8001:8001"

--- a/demos/use_cases/http_filter/http.rest
+++ b/demos/use_cases/http_filter/http.rest
@@ -8,7 +8,7 @@
 @queryRewriter = {{host}}:10501
 @contextBuilder = {{host}}:10502
 
-# Plano agent listener (the thing Open WebUI calls)
+# Plano agent listener (the thing AnythingLLM calls)
 @planoAgent = {{host}}:8001
 
 

--- a/demos/use_cases/llm_routing/docker-compose.yaml
+++ b/demos/use_cases/llm_routing/docker-compose.yaml
@@ -1,9 +1,7 @@
 services:
 
   plano:
-    build:
-      context: ../../../
-      dockerfile: Dockerfile
+    image: katanemo/plano:latest
     ports:
       - "12000:12000"
       - "12001:12001"

--- a/demos/use_cases/llm_routing/run_demo.sh
+++ b/demos/use_cases/llm_routing/run_demo.sh
@@ -18,11 +18,7 @@ start_demo() {
     echo ".env file created with OPENAI_API_KEY."
   fi
 
-  # Step 3: Start Plano
-  echo "Starting Plano with config.yaml..."
-  planoai up config.yaml
-
-  # Step 4: Start LLM Routing
+  # Step 3: Start LLM Routing
   echo "Starting LLM Routing using Docker Compose..."
   docker compose up -d  # Run in detached mode
 }
@@ -32,10 +28,6 @@ stop_demo() {
   # Step 1: Stop Docker Compose services
   echo "Stopping LLM Routing using Docker Compose..."
   docker compose down
-
-  # Step 2: Stop Plano
-  echo "Stopping Plano..."
-  planoai down
 }
 
 # Main script logic

--- a/demos/use_cases/mcp_filter/docker-compose.yaml
+++ b/demos/use_cases/mcp_filter/docker-compose.yaml
@@ -12,9 +12,7 @@ services:
       - LLM_GATEWAY_ENDPOINT=${LLM_GATEWAY_ENDPOINT:-http://host.docker.internal:12000/v1}
       - OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY environment variable is required but not set}
   plano:
-    build:
-      context: ../../../
-      dockerfile: Dockerfile
+    image: katanemo/plano:latest
     ports:
       - "11000:11000"
       - "12001:12001"

--- a/demos/use_cases/multi_agent_with_crewai_langchain/docker-compose.yaml
+++ b/demos/use_cases/multi_agent_with_crewai_langchain/docker-compose.yaml
@@ -1,9 +1,7 @@
 
 services:
   plano:
-    build:
-      context: ../../../
-      dockerfile: Dockerfile
+    image: katanemo/plano:latest
     ports:
       - "8001:8001"
       - "12000:12000"

--- a/demos/use_cases/preference_based_routing/docker-compose.yaml
+++ b/demos/use_cases/preference_based_routing/docker-compose.yaml
@@ -1,9 +1,7 @@
 services:
 
   plano:
-    build:
-      context: ../../../
-      dockerfile: Dockerfile
+    image: katanemo/plano:latest
     ports:
       - "12000:12000"
       - "12001:12001"

--- a/demos/use_cases/travel_agents/README.md
+++ b/demos/use_cases/travel_agents/README.md
@@ -49,14 +49,12 @@ docker compose up --build
 This starts:
 - Weather Agent on port 10510
 - Flight Agent on port 10520
-- Open WebUI on port 8080
+- AnythingLLM on port 3001
 - Plano Proxy on port 8001
 
 ### 4. Test the System
 
-Use Open WebUI at http://localhost:8080
-
-> **Note:** The Open WebUI may take a few minutes to start up and be fully ready. Please wait for the container to finish initializing before accessing the interface. Once ready, make sure to select the **gpt-5.2** model from the model dropdown menu in the UI.
+Use AnythingLLM at http://localhost:3001
 
 ## Example Conversations
 

--- a/demos/use_cases/travel_agents/docker-compose.yaml
+++ b/demos/use_cases/travel_agents/docker-compose.yaml
@@ -1,9 +1,7 @@
 
 services:
   plano:
-    build:
-      context: ../../../
-      dockerfile: Dockerfile
+    image: katanemo/plano:latest
     ports:
       - "12000:12000"
       - "8001:8001"
@@ -40,19 +38,20 @@ services:
     command: ["uv", "run", "python", "src/travel_agents/flight_agent.py"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
-  open-web-ui:
-    image: dyrnq/open-webui:main
+  anythingllm:
+    image: mintplexlabs/anythingllm
     restart: always
     ports:
-      - "8080:8080"
+      - "3001:3001"
+    cap_add:
+      - SYS_ADMIN
     environment:
-      - DEFAULT_MODEL=gpt-4o-mini
-      - ENABLE_OPENAI_API=true
-      - OPENAI_API_BASE_URL=http://host.docker.internal:8001/v1
-      - ENABLE_FOLLOW_UP_GENERATION=false
-      - ENABLE_TITLE_GENERATION=false
-      - ENABLE_TAGS_GENERATION=false
-      - ENABLE_AUTOCOMPLETE_GENERATION=false
+      - STORAGE_DIR=/app/server/storage
+      - LLM_PROVIDER=generic-openai
+      - GENERIC_OPEN_AI_BASE_PATH=http://plano:8001/v1
+      - GENERIC_OPEN_AI_MODEL_PREF=gpt-4o-mini
+      - GENERIC_OPEN_AI_MODEL_TOKEN_LIMIT=128000
+      - GENERIC_OPEN_AI_API_KEY=sk-placeholder
     depends_on:
       - weather-agent
       - flight-agent


### PR DESCRIPTION
- Replace Open WebUI with AnythingLLM in travel_agents demo
- Switch all demo plano services from local build to katanemo/plano:latest
- Update llm_routing run_demo.sh to remove planoai CLI calls (plano now in docker-compose)
- Clean up stale Open WebUI references in .gitignore and http_filter/http.rest