### PR TITLE
Upgrade Python base images to 3.13.11 to fix CVE-2025-13836

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN cargo build --release -p brightstaff
 
 FROM docker.io/envoyproxy/envoy:v1.37.0 AS envoy
 
-FROM python:3.13.6-slim AS arch
+FROM python:3.13.11-slim AS arch
 
 RUN set -eux; \
   apt-get update; \

--- a/demos/use_cases/http_filter/Dockerfile
+++ b/demos/use_cases/http_filter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.11-slim
 
 WORKDIR /app
 

--- a/demos/use_cases/mcp_filter/Dockerfile
+++ b/demos/use_cases/mcp_filter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.11-slim
 
 WORKDIR /app
 

--- a/demos/use_cases/multi_agent_with_crewai_langchain/Dockerfile
+++ b/demos/use_cases/multi_agent_with_crewai_langchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.11-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Upgrades Python base image in the main `Dockerfile` from `3.13.6-slim` to `3.13.11-slim`
- Updates emo Dockerfiles 

## Details
Python 3.13.11 includes the fix for [CVE-2025-13836](https://www.cve.org/CVERecord?id=CVE-2025-13836) (CWE-400, Critical) — a memory DoS in `http.client` where a malicious server can set an arbitrarily large `Content-Length`, causing OOM via unbounded buffer allocation. The fix introduces chunked reading with a 1 MB initial buffer (`_MIN_READ_BUF_SIZE`) and geometric growth.

Closes #750
