### PR TITLE
Add secret leak prevention to gitignore and pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ celerybeat-schedule
 
 # Environments
 .env
+.env.local
+.env*.local
 .venv
 env/
 venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
         entry: bash -c "cd crates && cargo test --lib"
         pass_filenames: false
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:


### PR DESCRIPTION
## Summary
- Add `.env.local` and `.env*.local` to `.gitignore` to prevent env files with secrets from being committed
- Add [gitleaks](https://github.com/gitleaks/gitleaks) pre-commit hook to scan for hardcoded secrets before every commit

This addresses leaked secrets found by a secrets scanner (Vercel API key in `demos/use_cases/vercel-ai-sdk/.env.local` and OpenAI API key in issue #232).

