### PR TITLE
Add Trivy Docker security scan to CI

### DIFF
--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -36,6 +36,7 @@ jobs:
           format: table
           # Fail on PRs so vulnerabilities block merge; on main just report
           exit-code: ${{ github.event_name == 'pull_request' && '1' || '0' }}
+          ignore-unfixed: true
           severity: CRITICAL,HIGH
 
       - name: Run Trivy scanner (SARIF for GitHub Security tab)
@@ -45,6 +46,7 @@ jobs:
           image-ref: ${{ env.DOCKER_IMAGE }}:scan
           format: sarif
           output: trivy-results.sarif
+          ignore-unfixed: true
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy results to GitHub Security tab

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "questionary>=2.1.1,<3.0.0",
     "pyyaml>=6.0.2,<7.0.0",
     "requests>=2.31.0,<3.0.0",
+    "urllib3>=2.6.3",
     "rich>=14.2.0",
     "rich-click>=1.9.5",
 ]

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -350,6 +350,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "rich-click" },
+    { name = "urllib3" },
 ]
 
 [package.optional-dependencies]
@@ -375,6 +376,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0,<3.0.0" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "rich-click", specifier = ">=1.9.5" },
+    { name = "urllib3", specifier = ">=2.6.3" },
 ]
 provides-extras = ["dev"]
 
@@ -742,11 +744,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that scans the Docker image for CRITICAL and HIGH vulnerabilities using [Trivy](https://github.com/aquasecurity/trivy)
- **On PRs**: scan failures block merge
- **On main**: scan runs non-blocking for visibility
- Results are uploaded to the GitHub Security tab via SARIF

