### PR TITLE
Make model field optional with default provider fallback

### DIFF
--- a/crates/brightstaff/src/main.rs
+++ b/crates/brightstaff/src/main.rs
@@ -202,6 +202,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                             fully_qualified_url,
                             agents_list,
                             listeners,
+                            llm_providers,
                         )
                         .with_context(parent_cx)
                         .await;

--- a/crates/hermesllm/src/apis/anthropic.rs
+++ b/crates/hermesllm/src/apis/anthropic.rs
@@ -102,6 +102,7 @@ pub struct McpServer {
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MessagesRequest {
+    #[serde(default)]
     pub model: String,
     pub messages: Vec<MessagesMessage>,
     pub max_tokens: u32,

--- a/crates/hermesllm/src/apis/openai.rs
+++ b/crates/hermesllm/src/apis/openai.rs
@@ -74,6 +74,7 @@ impl ApiDefinition for OpenAIApi {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct ChatCompletionsRequest {
     pub messages: Vec<Message>,
+    #[serde(default)]
     pub model: String,
     // pub audio: Option<Audio> // GOOD FIRST ISSUE: future support for audio input
     pub frequency_penalty: Option<f32>,

--- a/crates/hermesllm/src/apis/openai_responses.rs
+++ b/crates/hermesllm/src/apis/openai_responses.rs
@@ -29,6 +29,7 @@ impl TryFrom<&[u8]> for ResponsesAPIResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponsesAPIRequest {
     /// The model to use for generating the response
+    #[serde(default)]
     pub model: String,
 
     /// Text, image, or file inputs to the model


### PR DESCRIPTION
## Summary
- Make the `model` field optional (serde-defaultable) in `ChatCompletionsRequest`, `ResponsesAPIRequest`, and `MessagesRequest` across hermesllm
- When a client omits `model` from a request and a default provider is configured (`default: true`), automatically resolve to the default provider's model name
- If no model is specified and no default provider is configured, return a clear 400 error
- Applied to both the LLM handler (`llm_chat`) and agent chat handler (`agent_chat`)
