### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.1
 
   # ──────────────────────────────────────────────
@@ -33,10 +33,10 @@ jobs:
       run:
         working-directory: ./cli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free disk space on runner
         run: |
@@ -88,7 +88,7 @@ jobs:
         run: docker save ${{ env.PLANO_DOCKER_IMAGE }} ${{ env.DOCKER_IMAGE }}:0.4.8 ${{ env.DOCKER_IMAGE }}:latest -o /tmp/plano-image.tar
 
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: plano-image
           path: /tmp/plano-image.tar
@@ -102,15 +102,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
       - name: Download plano image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: plano-image
           path: /tmp
@@ -129,10 +129,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download plano image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: plano-image
           path: /tmp
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free disk space on runner
         run: |
@@ -182,7 +182,7 @@ jobs:
           docker volume prune -f || true
 
       - name: Download plano image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: plano-image
           path: /tmp
@@ -191,7 +191,7 @@ jobs:
         run: docker load -i /tmp/plano-image.tar
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free disk space on runner
         run: |
@@ -232,7 +232,7 @@ jobs:
           docker volume prune -f || true
 
       - name: Download plano image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: plano-image
           path: /tmp
@@ -241,7 +241,7 @@ jobs:
         run: docker load -i /tmp/plano-image.tar
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -273,7 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free disk space on runner
         run: |
@@ -282,7 +282,7 @@ jobs:
           docker volume prune -f || true
 
       - name: Download plano image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: plano-image
           path: /tmp
@@ -291,7 +291,7 @@ jobs:
         run: docker load -i /tmp/plano-image.tar
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -330,15 +330,15 @@ jobs:
         working-directory: ./tests/archgw
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download plano image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: plano-image
           path: /tmp
@@ -388,15 +388,15 @@ jobs:
     runs-on: ubuntu-latest-m
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
       - name: Download plano image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: plano-image
           path: /tmp
@@ -440,15 +440,15 @@ jobs:
     runs-on: ubuntu-latest-m
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
       - name: Download plano image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: plano-image
           path: /tmp

--- a/.github/workflows/docker-push-main.yml
+++ b/.github/workflows/docker-push-main.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [linux-arm64]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [linux-arm64]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # Check out the code from the repository
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       # Set up Docker
       - name: Set up Docker


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | ci.yml, docker-push-main.yml, docker-push-release.yml, publish-pypi.yml, static.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | ci.yml |
| `actions/setup-python` | [`v4`](https://github.com/actions/setup-python/releases/tag/v4), [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | ci.yml, publish-pypi.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | ci.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting June 2nd, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: June 2nd, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/checkout** (v3 → v6): Major version upgrade — review the [release notes](https://github.com/actions/checkout/releases) for breaking changes
- **actions/setup-python** (v4 → v6): Major version upgrade — review the [release notes](https://github.com/actions/setup-python/releases) for breaking changes
- **actions/upload-artifact** (v4 → v6): Major version upgrade — review the [release notes](https://github.com/actions/upload-artifact/releases) for breaking changes
- **actions/download-artifact** (v4 → v7): Major version upgrade — review the [release notes](https://github.com/actions/download-artifact/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
