### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -246,7 +246,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -296,7 +296,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: |

--- a/.github/workflows/docker-push-main.yml
+++ b/.github/workflows/docker-push-main.yml
@@ -35,7 +35,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push ARM64 Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
@@ -66,7 +66,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push AMD64 Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker-push-release.yml
+++ b/.github/workflows/docker-push-release.yml
@@ -42,7 +42,7 @@ jobs:
             type=raw,value={{tag}}
 
       - name: Build and Push ARM64 Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
@@ -81,7 +81,7 @@ jobs:
             type=raw,value={{tag}}
 
       - name: Build and Push AMD64 Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -17,7 +17,7 @@ jobs:
 
       # Set up Docker
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # Build and run the Docker container to generate the documentation
       - name: Build documentation using Docker
@@ -30,7 +30,7 @@ jobs:
 
       # Deploy the docs to GitHub Pages
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build/html  # Adjust this path based on where the HTML is generated


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `astral-sh/setup-uv` | [`v4`](https://github.com/astral-sh/setup-uv/releases/tag/v4), [`v5`](https://github.com/astral-sh/setup-uv/releases/tag/v5) | [`v7`](https://github.com/astral-sh/setup-uv/releases/tag/v7) | [Release](https://github.com/astral-sh/setup-uv/releases/tag/v7) | ci.yml, publish-pypi.yml |
| `docker/build-push-action` | [`v5`](https://github.com/docker/build-push-action/releases/tag/v5) | [`v6`](https://github.com/docker/build-push-action/releases/tag/v6) | [Release](https://github.com/docker/build-push-action/releases/tag/v6) | docker-push-main.yml, docker-push-release.yml |
| `docker/setup-buildx-action` | [`v2`](https://github.com/docker/setup-buildx-action/releases/tag/v2) | [`v3`](https://github.com/docker/setup-buildx-action/releases/tag/v3) | [Release](https://github.com/docker/setup-buildx-action/releases/tag/v3) | static.yml |
| `peaceiris/actions-gh-pages` | [`v3`](https://github.com/peaceiris/actions-gh-pages/releases/tag/v3) | [`v4`](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4) | [Release](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4) | static.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **docker/setup-buildx-action** (v2 → v3): Major version upgrade — review the [release notes](https://github.com/docker/setup-buildx-action/releases) for breaking changes
- **peaceiris/actions-gh-pages** (v3 → v4): Major version upgrade — review the [release notes](https://github.com/peaceiris/actions-gh-pages/releases) for breaking changes
- **astral-sh/setup-uv** (v4 → v7): Major version upgrade — review the [release notes](https://github.com/astral-sh/setup-uv/releases) for breaking changes
- **docker/build-push-action** (v5 → v6): Major version upgrade — review the [release notes](https://github.com/docker/build-push-action/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
