### PR TITLE
Add build-cli and build-brightstaff skills

### DIFF
--- a/.claude/skills/build-brightstaff/SKILL.md
+++ b/.claude/skills/build-brightstaff/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: build-brightstaff
+description: Build the brightstaff native binary. Use when brightstaff code changes.
+---
+
+Build brightstaff:
+
+```
+cd crates && cargo build --release -p brightstaff
+```
+
+If the build fails, diagnose and fix the errors.

--- a/.claude/skills/build-cli/SKILL.md
+++ b/.claude/skills/build-cli/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: build-cli
+description: Build and install the Python CLI (planoai). Use after making changes to cli/ code to install locally.
+---
+
+1. `cd cli && uv sync` — ensure dependencies are installed
+2. `cd cli && uv tool install --editable .` — install the CLI locally
+3. Verify the installation: `cd cli && uv run planoai --help`
+
+If the build or install fails, diagnose and fix the issues.


### PR DESCRIPTION
## Summary
- Add `build-cli` skill for building and installing the Python CLI locally
- Add `build-brightstaff` skill for building the brightstaff native binary