### PR TITLE
Improve config validation error messages

### DIFF
--- a/cli/planoai/config_generator.py
+++ b/cli/planoai/config_generator.py
@@ -8,7 +8,6 @@ from urllib.parse import urlparse
 from copy import deepcopy
 from planoai.consts import DEFAULT_OTEL_TRACING_GRPC_ENDPOINT
 
-
 SUPPORTED_PROVIDERS_WITH_BASE_URL = [
     "azure_openai",
     "ollama",
@@ -504,7 +503,9 @@ def validate_prompt_config(plano_config_file, plano_config_schema_file):
     try:
         validate(config_yaml, config_schema_yaml)
     except ValidationError as e:
-        path = " → ".join(str(p) for p in e.absolute_path) if e.absolute_path else "root"
+        path = (
+            " → ".join(str(p) for p in e.absolute_path) if e.absolute_path else "root"
+        )
         raise ValidationError(
             f"{e.message}\n  Location: {path}\n  Value: {e.instance}"
         ) from None

--- a/cli/planoai/native_runner.py
+++ b/cli/planoai/native_runner.py
@@ -429,9 +429,7 @@ def native_validate_config(plano_config_file):
             # validate_and_render_schema calls exit(1) on failure after
             # printing to stdout; re-raise so the caller gets a useful message.
             output = captured.getvalue().strip()
-            raise Exception(output) if output else Exception(
-                "Config validation failed"
-            )
+            raise Exception(output) if output else Exception("Config validation failed")
 
 
 def native_logs(debug=False, follow=False):


### PR DESCRIPTION
## Summary
- Show human-readable validation errors with location path and offending value instead of raw jsonschema exceptions
- Properly capture and re-raise config validation errors in native runner instead of silently swallowing them


with this change,
```
(planoai) ➜  llm_gateway git:(main) ✗ planoai up                  

Plano CLI v0.4.11

✗ Validation failed
  Additional properties are not allowed ('filter_chain' was unexpected)
  Location: listeners → 0
  Value: {'type': 'model', 'name': 'llm_gateway', 'port': 12000, 
'filter_chain': ['jailbreak_guard', 'pii_redactor']}
(planoai) ➜  llm_gateway git:(main) ✗ 
```

before
```
(planoai) ➜  llm_gateway git:(main) ✗ planoai up

Plano CLI v0.4.11

✗ Validation failed
(planoai) ➜  llm_gateway git:(main) ✗ 
```