### PR TITLE
fix CVE-2026-0861: upgrade glibc via apt-get upgrade in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ FROM python:3.14-slim AS arch
 
 RUN set -eux; \
   apt-get update; \
+  apt-get upgrade -y; \
   apt-get install -y --no-install-recommends gettext-base curl; \
   apt-get clean; rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- CVE-2026-0861 (HIGH): glibc integer overflow in `libc6`/`libc-bin` (`2.41-12+deb13u1`) now has a fix available in `2.41-12+deb13u2`
- Previously `ignore-unfixed: true` in the Trivy scan suppressed this, but since Debian released the patch it started failing
- Added `apt-get upgrade -y` to the Dockerfile so the image pulls the patched glibc on build