### PR TITLE
replace production panics with graceful error handling in common crate

### DIFF
--- a/crates/common/src/api/open_ai.rs
+++ b/crates/common/src/api/open_ai.rs
@@ -2,7 +2,6 @@ use crate::{
     configuration::LlmProvider,
     consts::{ARCH_FC_MODEL_NAME, ASSISTANT_ROLE},
 };
-use core::{panic, str};
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 use std::{
     collections::{HashMap, VecDeque},
@@ -193,7 +192,7 @@ impl Display for ContentType {
                             // skip image URLs or their data in text representation
                             None
                         } else {
-                            panic!("Unsupported content type: {:?}", part.content_type);
+                            None
                         }
                     })
                     .collect();

--- a/crates/common/src/http.rs
+++ b/crates/common/src/http.rs
@@ -75,7 +75,10 @@ pub trait Client: Context {
     fn add_call_context(&self, id: u32, call_context: Self::CallContext) {
         let callouts = self.callouts();
         if callouts.borrow_mut().insert(id, call_context).is_some() {
-            panic!("Duplicate http call with id={}", id);
+            log::warn!(
+                "Duplicate http call with id={}, previous context overwritten",
+                id
+            );
         }
         self.active_http_calls().increment(1);
     }

--- a/crates/common/src/ratelimit.rs
+++ b/crates/common/src/ratelimit.rs
@@ -73,7 +73,10 @@ impl RatelimitMap {
             match new_ratelimit_map.datastore.get_mut(&ratelimit_config.model) {
                 Some(limits) => match limits.get_mut(&ratelimit_config.selector) {
                     Some(_) => {
-                        panic!("repeated selector. Selectors per provider must be unique")
+                        log::error!(
+                            "repeated selector for model '{}'. Selectors per provider must be unique, skipping duplicate",
+                            ratelimit_config.model
+                        );
                     }
                     None => {
                         limits.insert(ratelimit_config.selector, limit);


### PR DESCRIPTION
## Summary
- **`open_ai.rs`**: Replace `panic!("Unsupported content type")` in `Display` impl with silently skipping unknown content types (same as `ImageUrl` handling) — prevents crash when logging messages with new content types
- **`ratelimit.rs`**: Replace `panic!("repeated selector")` with `log::error!` and skip the duplicate — prevents crash on config typo with duplicate rate limit selectors  
- **`http.rs`**: Replace `panic!("Duplicate http call")` with `log::warn!` — prevents crash if proxy-wasm runtime generates a duplicate call token ID

Also removes unused `core::{panic, str}` import that became dead code after the fix.

## Test plan
- [x] `cargo test --lib -p common` — all 36 tests pass
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean