### PR TITLE
Zero-config planoai up: pass-through proxy with auto-detected providers

### DIFF
--- a/cli/planoai/defaults.py
+++ b/cli/planoai/defaults.py
@@ -72,14 +72,13 @@ PROVIDER_DEFAULTS: list[ProviderDefault] = [
         base_url="https://api.mistral.ai/v1",
         model_pattern="mistral/*",
     ),
-    # DigitalOcean Gradient is OpenAI-compatible and `do` is not in the built-in
-    # SUPPORTED_PROVIDERS list, so we must provide provider_interface explicitly.
+    # DigitalOcean Gradient is now a first-class provider (see #889) — model
+    # prefix `digitalocean/` routes to the built-in cluster, no base_url needed.
     ProviderDefault(
-        name="do",
+        name="digitalocean",
         env_var="DO_API_KEY",
         base_url="https://inference.do-ai.run/v1",
-        model_pattern="do/*",
-        provider_interface="openai",
+        model_pattern="digitalocean/*",
     ),
 ]
 

--- a/cli/planoai/defaults.py
+++ b/cli/planoai/defaults.py
@@ -1,0 +1,167 @@
+"""Default config synthesizer for zero-config ``planoai up``.
+
+When the user runs ``planoai up`` in a directory with no ``config.yaml`` /
+``plano_config.yaml``, we synthesize a pass-through config that covers the
+common LLM providers and auto-wires OTel export to ``localhost:4317`` so
+``planoai obs`` works out of the box.
+
+Auth handling:
+- If the provider's env var is set, bind ``access_key: $ENV_VAR``.
+- Otherwise set ``passthrough_auth: true`` so the client's own Authorization
+  header is forwarded. No env var is required to start the proxy.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+DEFAULT_LLM_LISTENER_PORT = 12000
+# plano_config validation requires an http:// scheme on the OTLP endpoint.
+DEFAULT_OTLP_ENDPOINT = "http://localhost:4317"
+
+
+@dataclass(frozen=True)
+class ProviderDefault:
+    name: str
+    env_var: str
+    base_url: str
+    model_pattern: str
+    # Only set for providers whose prefix in the model pattern is NOT one of the
+    # built-in SUPPORTED_PROVIDERS in cli/planoai/config_generator.py. For
+    # built-ins, the validator infers the interface from the model prefix and
+    # rejects configs that set this field explicitly.
+    provider_interface: str | None = None
+
+
+# Keep ordering stable so synthesized configs diff cleanly across runs.
+PROVIDER_DEFAULTS: list[ProviderDefault] = [
+    ProviderDefault(
+        name="openai",
+        env_var="OPENAI_API_KEY",
+        base_url="https://api.openai.com/v1",
+        model_pattern="openai/*",
+    ),
+    ProviderDefault(
+        name="anthropic",
+        env_var="ANTHROPIC_API_KEY",
+        base_url="https://api.anthropic.com/v1",
+        model_pattern="anthropic/*",
+    ),
+    ProviderDefault(
+        name="gemini",
+        env_var="GEMINI_API_KEY",
+        base_url="https://generativelanguage.googleapis.com/v1beta",
+        model_pattern="gemini/*",
+    ),
+    ProviderDefault(
+        name="groq",
+        env_var="GROQ_API_KEY",
+        base_url="https://api.groq.com/openai/v1",
+        model_pattern="groq/*",
+    ),
+    ProviderDefault(
+        name="deepseek",
+        env_var="DEEPSEEK_API_KEY",
+        base_url="https://api.deepseek.com/v1",
+        model_pattern="deepseek/*",
+    ),
+    ProviderDefault(
+        name="mistral",
+        env_var="MISTRAL_API_KEY",
+        base_url="https://api.mistral.ai/v1",
+        model_pattern="mistral/*",
+    ),
+    # DigitalOcean Gradient is OpenAI-compatible and `do` is not in the built-in
+    # SUPPORTED_PROVIDERS list, so we must provide provider_interface explicitly.
+    ProviderDefault(
+        name="do",
+        env_var="DO_API_KEY",
+        base_url="https://inference.do-ai.run/v1",
+        model_pattern="do/*",
+        provider_interface="openai",
+    ),
+]
+
+
+@dataclass
+class DetectionResult:
+    with_keys: list[ProviderDefault]
+    passthrough: list[ProviderDefault]
+
+    @property
+    def summary(self) -> str:
+        parts = []
+        if self.with_keys:
+            parts.append(
+                "env-keyed: " + ", ".join(p.name for p in self.with_keys)
+            )
+        if self.passthrough:
+            parts.append(
+                "pass-through: " + ", ".join(p.name for p in self.passthrough)
+            )
+        return " | ".join(parts) if parts else "no providers"
+
+
+def detect_providers(env: dict[str, str] | None = None) -> DetectionResult:
+    env = env if env is not None else dict(os.environ)
+    with_keys: list[ProviderDefault] = []
+    passthrough: list[ProviderDefault] = []
+    for p in PROVIDER_DEFAULTS:
+        val = env.get(p.env_var)
+        if val:
+            with_keys.append(p)
+        else:
+            passthrough.append(p)
+    return DetectionResult(with_keys=with_keys, passthrough=passthrough)
+
+
+def synthesize_default_config(
+    env: dict[str, str] | None = None,
+    *,
+    listener_port: int = DEFAULT_LLM_LISTENER_PORT,
+    otel_endpoint: str = DEFAULT_OTLP_ENDPOINT,
+) -> dict:
+    """Build a pass-through config dict suitable for validation + envoy rendering.
+
+    The returned dict can be dumped to YAML and handed to the existing `planoai up`
+    pipeline unchanged.
+    """
+    detection = detect_providers(env)
+
+    def _entry(p: ProviderDefault, base: dict) -> dict:
+        row: dict = {"name": p.name, "model": p.model_pattern, "base_url": p.base_url}
+        if p.provider_interface is not None:
+            row["provider_interface"] = p.provider_interface
+        row.update(base)
+        return row
+
+    model_providers: list[dict] = []
+    for p in detection.with_keys:
+        model_providers.append(_entry(p, {"access_key": f"${p.env_var}"}))
+    for p in detection.passthrough:
+        model_providers.append(_entry(p, {"passthrough_auth": True}))
+
+    # We intentionally don't mark any provider as `default: true` here:
+    # the validator rejects wildcard models (e.g. `openai/*`) as defaults, and
+    # all our entries are wildcards. Clients should prefix model names (e.g.
+    # `openai/gpt-4o-mini`, `do/router:software-engineering`); the wildcard
+    # matcher routes them to the correct provider.
+
+    return {
+        "version": "v0.4.0",
+        "listeners": [
+            {
+                "name": "llm",
+                "type": "model",
+                "port": listener_port,
+                "address": "0.0.0.0",
+            }
+        ],
+        "model_providers": model_providers,
+        "tracing": {
+            "random_sampling": 100,
+            "opentracing_grpc_endpoint": otel_endpoint,
+        },
+    }

--- a/cli/planoai/defaults.py
+++ b/cli/planoai/defaults.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-
 DEFAULT_LLM_LISTENER_PORT = 12000
 # plano_config validation requires an http:// scheme on the OTLP endpoint.
 DEFAULT_OTLP_ENDPOINT = "http://localhost:4317"
@@ -94,13 +93,9 @@ class DetectionResult:
     def summary(self) -> str:
         parts = []
         if self.with_keys:
-            parts.append(
-                "env-keyed: " + ", ".join(p.name for p in self.with_keys)
-            )
+            parts.append("env-keyed: " + ", ".join(p.name for p in self.with_keys))
         if self.passthrough:
-            parts.append(
-                "pass-through: " + ", ".join(p.name for p in self.passthrough)
-            )
+            parts.append("pass-through: " + ", ".join(p.name for p in self.passthrough))
         return " | ".join(parts) if parts else "no providers"
 
 

--- a/cli/planoai/defaults.py
+++ b/cli/planoai/defaults.py
@@ -27,6 +27,10 @@ class ProviderDefault:
     env_var: str
     base_url: str
     model_pattern: str
+    # Concrete, small, cheap model to promote to `default: true` in the
+    # synthesized config when this provider has an env key. Lets clients send
+    # bare (unprefixed) model names that Plano otherwise rejects.
+    default_model: str | None = None
     # Only set for providers whose prefix in the model pattern is NOT one of the
     # built-in SUPPORTED_PROVIDERS in cli/planoai/config_generator.py. For
     # built-ins, the validator infers the interface from the model prefix and
@@ -41,18 +45,21 @@ PROVIDER_DEFAULTS: list[ProviderDefault] = [
         env_var="OPENAI_API_KEY",
         base_url="https://api.openai.com/v1",
         model_pattern="openai/*",
+        default_model="gpt-4o-mini",
     ),
     ProviderDefault(
         name="anthropic",
         env_var="ANTHROPIC_API_KEY",
         base_url="https://api.anthropic.com/v1",
         model_pattern="anthropic/*",
+        default_model="claude-haiku-4-5",
     ),
     ProviderDefault(
         name="gemini",
         env_var="GEMINI_API_KEY",
         base_url="https://generativelanguage.googleapis.com/v1beta",
         model_pattern="gemini/*",
+        default_model="gemini-2.5-flash",
     ),
     ProviderDefault(
         name="groq",
@@ -79,6 +86,7 @@ PROVIDER_DEFAULTS: list[ProviderDefault] = [
         env_var="DO_API_KEY",
         base_url="https://inference.do-ai.run/v1",
         model_pattern="digitalocean/*",
+        default_model="openai-gpt-5.4-mini",
     ),
 ]
 
@@ -137,11 +145,27 @@ def synthesize_default_config(
     for p in detection.passthrough:
         model_providers.append(_entry(p, {"passthrough_auth": True}))
 
-    # We intentionally don't mark any provider as `default: true` here:
-    # the validator rejects wildcard models (e.g. `openai/*`) as defaults, and
-    # all our entries are wildcards. Clients should prefix model names (e.g.
-    # `openai/gpt-4o-mini`, `do/router:software-engineering`); the wildcard
-    # matcher routes them to the correct provider.
+    # Promote the first env-keyed provider that ships a `default_model` to a
+    # concrete `default: true` entry. This lets clients send bare (unprefixed)
+    # model names and still route somewhere sensible. Wildcards can't be marked
+    # default (the validator rejects it), so we add a second concrete row.
+    #
+    # When no env keys are present, we leave `default` unset: the user is fully
+    # in pass-through mode and must prefix model names so Plano knows which
+    # upstream to route to.
+    default_picked = next(
+        (p for p in detection.with_keys if p.default_model is not None), None
+    )
+    if default_picked is not None:
+        model_providers.append(
+            {
+                "name": f"{default_picked.name}/{default_picked.default_model}",
+                "model": f"{default_picked.name}/{default_picked.default_model}",
+                "base_url": default_picked.base_url,
+                "access_key": f"${default_picked.env_var}",
+                "default": True,
+            }
+        )
 
     return {
         "version": "v0.4.0",

--- a/cli/planoai/defaults.py
+++ b/cli/planoai/defaults.py
@@ -27,10 +27,6 @@ class ProviderDefault:
     env_var: str
     base_url: str
     model_pattern: str
-    # Concrete, small, cheap model to promote to `default: true` in the
-    # synthesized config when this provider has an env key. Lets clients send
-    # bare (unprefixed) model names that Plano otherwise rejects.
-    default_model: str | None = None
     # Only set for providers whose prefix in the model pattern is NOT one of the
     # built-in SUPPORTED_PROVIDERS in cli/planoai/config_generator.py. For
     # built-ins, the validator infers the interface from the model prefix and
@@ -45,21 +41,18 @@ PROVIDER_DEFAULTS: list[ProviderDefault] = [
         env_var="OPENAI_API_KEY",
         base_url="https://api.openai.com/v1",
         model_pattern="openai/*",
-        default_model="gpt-4o-mini",
     ),
     ProviderDefault(
         name="anthropic",
         env_var="ANTHROPIC_API_KEY",
         base_url="https://api.anthropic.com/v1",
         model_pattern="anthropic/*",
-        default_model="claude-haiku-4-5",
     ),
     ProviderDefault(
         name="gemini",
         env_var="GEMINI_API_KEY",
         base_url="https://generativelanguage.googleapis.com/v1beta",
         model_pattern="gemini/*",
-        default_model="gemini-2.5-flash",
     ),
     ProviderDefault(
         name="groq",
@@ -79,14 +72,14 @@ PROVIDER_DEFAULTS: list[ProviderDefault] = [
         base_url="https://api.mistral.ai/v1",
         model_pattern="mistral/*",
     ),
-    # DigitalOcean Gradient is now a first-class provider (see #889) — model
-    # prefix `digitalocean/` routes to the built-in cluster, no base_url needed.
+    # DigitalOcean Gradient is a first-class provider post-#889 — the
+    # `digitalocean/` model prefix routes to the built-in Envoy cluster, no
+    # base_url needed at runtime.
     ProviderDefault(
         name="digitalocean",
         env_var="DO_API_KEY",
         base_url="https://inference.do-ai.run/v1",
         model_pattern="digitalocean/*",
-        default_model="openai-gpt-5.4-mini",
     ),
 ]
 
@@ -145,27 +138,12 @@ def synthesize_default_config(
     for p in detection.passthrough:
         model_providers.append(_entry(p, {"passthrough_auth": True}))
 
-    # Promote the first env-keyed provider that ships a `default_model` to a
-    # concrete `default: true` entry. This lets clients send bare (unprefixed)
-    # model names and still route somewhere sensible. Wildcards can't be marked
-    # default (the validator rejects it), so we add a second concrete row.
-    #
-    # When no env keys are present, we leave `default` unset: the user is fully
-    # in pass-through mode and must prefix model names so Plano knows which
-    # upstream to route to.
-    default_picked = next(
-        (p for p in detection.with_keys if p.default_model is not None), None
-    )
-    if default_picked is not None:
-        model_providers.append(
-            {
-                "name": f"{default_picked.name}/{default_picked.default_model}",
-                "model": f"{default_picked.name}/{default_picked.default_model}",
-                "base_url": default_picked.base_url,
-                "access_key": f"${default_picked.env_var}",
-                "default": True,
-            }
-        )
+    # No explicit `default: true` entry is synthesized: the plano config
+    # validator rejects wildcard models as defaults, and brightstaff already
+    # registers bare model names as lookup keys during wildcard expansion
+    # (crates/common/src/llm_providers.rs), so `{"model": "gpt-4o-mini"}`
+    # without a prefix resolves via the openai wildcard without needing
+    # `default: true`. See discussion on #890.
 
     return {
         "version": "v0.4.0",

--- a/cli/planoai/main.py
+++ b/cli/planoai/main.py
@@ -6,7 +6,13 @@ import sys
 import contextlib
 import logging
 import rich_click as click
+import yaml
 from planoai import targets
+from planoai.defaults import (
+    DEFAULT_LLM_LISTENER_PORT,
+    detect_providers,
+    synthesize_default_config,
+)
 
 # Brand color - Plano purple
 PLANO_COLOR = "#969FF4"
@@ -317,7 +323,23 @@ def build(docker):
     help="Show detailed startup logs with timestamps.",
     is_flag=True,
 )
-def up(file, path, foreground, with_tracing, tracing_port, docker, verbose):
+@click.option(
+    "--listener-port",
+    default=DEFAULT_LLM_LISTENER_PORT,
+    type=int,
+    show_default=True,
+    help="Override the LLM listener port when running without a config file. Ignored when a config file is present.",
+)
+def up(
+    file,
+    path,
+    foreground,
+    with_tracing,
+    tracing_port,
+    docker,
+    verbose,
+    listener_port,
+):
     """Starts Plano."""
     from rich.status import Status
 
@@ -332,15 +354,8 @@ def up(file, path, foreground, with_tracing, tracing_port, docker, verbose):
         # pass-through config that covers the common LLM providers and
         # auto-wires OTel export to ``planoai obs``. See cli/planoai/defaults.py.
         if not os.path.exists(plano_config_file):
-            import yaml
-
-            from planoai.defaults import (
-                detect_providers,
-                synthesize_default_config,
-            )
-
             detection = detect_providers()
-            cfg_dict = synthesize_default_config()
+            cfg_dict = synthesize_default_config(listener_port=listener_port)
 
             default_dir = os.path.expanduser("~/.plano")
             os.makedirs(default_dir, exist_ok=True)
@@ -350,7 +365,7 @@ def up(file, path, foreground, with_tracing, tracing_port, docker, verbose):
             plano_config_file = synthesized_path
             console.print(
                 f"[dim]No plano config found; using defaults ({detection.summary}). "
-                f"Listening on :12000, tracing -> http://localhost:4317.[/dim]"
+                f"Listening on :{listener_port}, tracing -> http://localhost:4317.[/dim]"
             )
 
         if not docker:

--- a/cli/planoai/main.py
+++ b/cli/planoai/main.py
@@ -328,12 +328,30 @@ def up(file, path, foreground, with_tracing, tracing_port, docker, verbose):
         # Use the utility function to find config file
         plano_config_file = find_config_file(path, file)
 
-        # Check if the file exists
+        # Zero-config fallback: when no user config is present, synthesize a
+        # pass-through config that covers the common LLM providers and
+        # auto-wires OTel export to ``planoai obs``. See cli/planoai/defaults.py.
         if not os.path.exists(plano_config_file):
-            console.print(
-                f"[red]✗[/red] Config file not found: [dim]{plano_config_file}[/dim]"
+            import yaml
+
+            from planoai.defaults import (
+                detect_providers,
+                synthesize_default_config,
             )
-            sys.exit(1)
+
+            detection = detect_providers()
+            cfg_dict = synthesize_default_config()
+
+            default_dir = os.path.expanduser("~/.plano")
+            os.makedirs(default_dir, exist_ok=True)
+            synthesized_path = os.path.join(default_dir, "default_config.yaml")
+            with open(synthesized_path, "w") as fh:
+                yaml.safe_dump(cfg_dict, fh, sort_keys=False)
+            plano_config_file = synthesized_path
+            console.print(
+                f"[dim]No plano config found; using defaults ({detection.summary}). "
+                f"Listening on :12000, tracing -> http://localhost:4317.[/dim]"
+            )
 
         if not docker:
             from planoai.native_runner import native_validate_config

--- a/cli/test/test_defaults.py
+++ b/cli/test/test_defaults.py
@@ -44,24 +44,13 @@ def test_env_keys_promote_providers_to_env_keyed():
     assert by_name["anthropic"].get("passthrough_auth") is True
 
 
-def test_first_env_keyed_provider_becomes_default():
+def test_no_default_is_synthesized():
+    # Bare model names resolve via brightstaff's wildcard expansion registering
+    # bare keys, so the synthesizer intentionally never sets `default: true`.
     cfg = synthesize_default_config(
         env={"OPENAI_API_KEY": "sk-1", "ANTHROPIC_API_KEY": "a-1"}
     )
-    defaults = [p for p in cfg["model_providers"] if p.get("default") is True]
-    assert len(defaults) == 1
-    # openai appears first in PROVIDER_DEFAULTS so it wins.
-    assert defaults[0]["model"] == "openai/gpt-4o-mini"
-    assert defaults[0]["access_key"] == "$OPENAI_API_KEY"
-
-
-def test_default_skips_providers_without_default_model():
-    # Groq has no default_model wired up — the next env-keyed provider with one
-    # should be picked instead.
-    cfg = synthesize_default_config(env={"GROQ_API_KEY": "g", "ANTHROPIC_API_KEY": "a"})
-    defaults = [p for p in cfg["model_providers"] if p.get("default") is True]
-    assert len(defaults) == 1
-    assert defaults[0]["model"].startswith("anthropic/")
+    assert not any(p.get("default") is True for p in cfg["model_providers"])
 
 
 def test_listener_port_is_configurable():

--- a/cli/test/test_defaults.py
+++ b/cli/test/test_defaults.py
@@ -23,6 +23,8 @@ def test_zero_env_vars_produces_pure_passthrough():
     for provider in cfg["model_providers"]:
         assert provider.get("passthrough_auth") is True
         assert "access_key" not in provider
+        # No provider should be marked default in pure pass-through mode.
+        assert provider.get("default") is not True
     # All known providers should be listed.
     names = {p["name"] for p in cfg["model_providers"]}
     assert "digitalocean" in names
@@ -40,6 +42,31 @@ def test_env_keys_promote_providers_to_env_keyed():
     assert by_name["digitalocean"].get("access_key") == "$DO_API_KEY"
     # Unset env keys remain pass-through.
     assert by_name["anthropic"].get("passthrough_auth") is True
+
+
+def test_first_env_keyed_provider_becomes_default():
+    cfg = synthesize_default_config(
+        env={"OPENAI_API_KEY": "sk-1", "ANTHROPIC_API_KEY": "a-1"}
+    )
+    defaults = [p for p in cfg["model_providers"] if p.get("default") is True]
+    assert len(defaults) == 1
+    # openai appears first in PROVIDER_DEFAULTS so it wins.
+    assert defaults[0]["model"] == "openai/gpt-4o-mini"
+    assert defaults[0]["access_key"] == "$OPENAI_API_KEY"
+
+
+def test_default_skips_providers_without_default_model():
+    # Groq has no default_model wired up — the next env-keyed provider with one
+    # should be picked instead.
+    cfg = synthesize_default_config(env={"GROQ_API_KEY": "g", "ANTHROPIC_API_KEY": "a"})
+    defaults = [p for p in cfg["model_providers"] if p.get("default") is True]
+    assert len(defaults) == 1
+    assert defaults[0]["model"].startswith("anthropic/")
+
+
+def test_listener_port_is_configurable():
+    cfg = synthesize_default_config(env={}, listener_port=11000)
+    assert cfg["listeners"][0]["port"] == 11000
 
 
 def test_detection_summary_strings():

--- a/cli/test/test_defaults.py
+++ b/cli/test/test_defaults.py
@@ -9,7 +9,6 @@ from planoai.defaults import (
     synthesize_default_config,
 )
 
-
 _SCHEMA_PATH = Path(__file__).parents[2] / "config" / "plano_config_schema.yaml"
 
 

--- a/cli/test/test_defaults.py
+++ b/cli/test/test_defaults.py
@@ -25,7 +25,7 @@ def test_zero_env_vars_produces_pure_passthrough():
         assert "access_key" not in provider
     # All known providers should be listed.
     names = {p["name"] for p in cfg["model_providers"]}
-    assert "do" in names
+    assert "digitalocean" in names
     assert "openai" in names
     assert "anthropic" in names
 
@@ -37,7 +37,7 @@ def test_env_keys_promote_providers_to_env_keyed():
     by_name = {p["name"]: p for p in cfg["model_providers"]}
     assert by_name["openai"].get("access_key") == "$OPENAI_API_KEY"
     assert by_name["openai"].get("passthrough_auth") is None
-    assert by_name["do"].get("access_key") == "$DO_API_KEY"
+    assert by_name["digitalocean"].get("access_key") == "$DO_API_KEY"
     # Unset env keys remain pass-through.
     assert by_name["anthropic"].get("passthrough_auth") is True
 
@@ -45,7 +45,7 @@ def test_env_keys_promote_providers_to_env_keyed():
 def test_detection_summary_strings():
     det = detect_providers(env={"OPENAI_API_KEY": "sk", "DO_API_KEY": "d"})
     summary = det.summary
-    assert "env-keyed" in summary and "openai" in summary and "do" in summary
+    assert "env-keyed" in summary and "openai" in summary and "digitalocean" in summary
     assert "pass-through" in summary
 
 
@@ -62,9 +62,9 @@ def test_synthesized_config_validates_against_schema():
     jsonschema.validate(cfg, _schema())
 
 
-def test_provider_defaults_do_is_configured():
+def test_provider_defaults_digitalocean_is_configured():
     by_name = {p.name: p for p in PROVIDER_DEFAULTS}
-    assert "do" in by_name
-    assert by_name["do"].env_var == "DO_API_KEY"
-    assert by_name["do"].base_url == "https://inference.do-ai.run/v1"
-    assert by_name["do"].model_pattern == "do/*"
+    assert "digitalocean" in by_name
+    assert by_name["digitalocean"].env_var == "DO_API_KEY"
+    assert by_name["digitalocean"].base_url == "https://inference.do-ai.run/v1"
+    assert by_name["digitalocean"].model_pattern == "digitalocean/*"

--- a/cli/test/test_defaults.py
+++ b/cli/test/test_defaults.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+from planoai.defaults import (
+    PROVIDER_DEFAULTS,
+    detect_providers,
+    synthesize_default_config,
+)
+
+
+_SCHEMA_PATH = Path(__file__).parents[2] / "config" / "plano_config_schema.yaml"
+
+
+def _schema() -> dict:
+    return yaml.safe_load(_SCHEMA_PATH.read_text())
+
+
+def test_zero_env_vars_produces_pure_passthrough():
+    cfg = synthesize_default_config(env={})
+    assert cfg["version"] == "v0.4.0"
+    assert cfg["listeners"][0]["port"] == 12000
+    for provider in cfg["model_providers"]:
+        assert provider.get("passthrough_auth") is True
+        assert "access_key" not in provider
+    # All known providers should be listed.
+    names = {p["name"] for p in cfg["model_providers"]}
+    assert "do" in names
+    assert "openai" in names
+    assert "anthropic" in names
+
+
+def test_env_keys_promote_providers_to_env_keyed():
+    cfg = synthesize_default_config(
+        env={"OPENAI_API_KEY": "sk-1", "DO_API_KEY": "do-1"}
+    )
+    by_name = {p["name"]: p for p in cfg["model_providers"]}
+    assert by_name["openai"].get("access_key") == "$OPENAI_API_KEY"
+    assert by_name["openai"].get("passthrough_auth") is None
+    assert by_name["do"].get("access_key") == "$DO_API_KEY"
+    # Unset env keys remain pass-through.
+    assert by_name["anthropic"].get("passthrough_auth") is True
+
+
+def test_detection_summary_strings():
+    det = detect_providers(env={"OPENAI_API_KEY": "sk", "DO_API_KEY": "d"})
+    summary = det.summary
+    assert "env-keyed" in summary and "openai" in summary and "do" in summary
+    assert "pass-through" in summary
+
+
+def test_tracing_block_points_at_local_console():
+    cfg = synthesize_default_config(env={})
+    tracing = cfg["tracing"]
+    assert tracing["opentracing_grpc_endpoint"] == "http://localhost:4317"
+    # random_sampling is a percentage in the plano config — 100 = every span.
+    assert tracing["random_sampling"] == 100
+
+
+def test_synthesized_config_validates_against_schema():
+    cfg = synthesize_default_config(env={"OPENAI_API_KEY": "sk"})
+    jsonschema.validate(cfg, _schema())
+
+
+def test_provider_defaults_do_is_configured():
+    by_name = {p.name: p for p in PROVIDER_DEFAULTS}
+    assert "do" in by_name
+    assert by_name["do"].env_var == "DO_API_KEY"
+    assert by_name["do"].base_url == "https://inference.do-ai.run/v1"
+    assert by_name["do"].model_pattern == "do/*"

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -337,7 +337,7 @@ wheels = [
 
 [[package]]
 name = "planoai"
-version = "0.4.18"
+version = "0.4.19"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/config/plano_config_schema.yaml
+++ b/config/plano_config_schema.yaml
@@ -190,6 +190,7 @@ properties:
             - openai
             - xiaomi
             - gemini
+            - digitalocean
         routing_preferences:
           type: array
           items:
@@ -238,6 +239,7 @@ properties:
             - openai
             - xiaomi
             - gemini
+            - digitalocean
         routing_preferences:
           type: array
           items:

--- a/crates/common/src/configuration.rs
+++ b/crates/common/src/configuration.rs
@@ -391,6 +391,8 @@ pub enum LlmProviderType {
     AmazonBedrock,
     #[serde(rename = "plano")]
     Plano,
+    #[serde(rename = "digitalocean")]
+    DigitalOcean,
 }
 
 impl Display for LlmProviderType {
@@ -412,6 +414,7 @@ impl Display for LlmProviderType {
             LlmProviderType::Qwen => write!(f, "qwen"),
             LlmProviderType::AmazonBedrock => write!(f, "amazon_bedrock"),
             LlmProviderType::Plano => write!(f, "plano"),
+            LlmProviderType::DigitalOcean => write!(f, "digitalocean"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- `planoai up` now works with no config file: synthesizes a pass-through proxy covering the common LLM providers (OpenAI, Anthropic, Gemini, Groq, DeepSeek, Mistral, DO) on the default listener port `:12000`.
- For providers with their env var set (`OPENAI_API_KEY`, etc.), Plano binds the key via `access_key: \$ENV_VAR`. For providers without env keys, it sets `passthrough_auth: true` so the client's own `Authorization` header is forwarded. No env vars are required to start.
- Tracing is auto-wired to `http://localhost:4317` with full sampling, so observability tooling (`planoai trace`, planned `planoai obs`) works out of the box.
- Synthesized config is written to `~/.plano/default_config.yaml` and handed through the existing validate+render pipeline unchanged; explicit user-provided configs still take precedence.

## Test plan
- [ ] `cd cli && uv run pytest test/test_defaults.py` (6 new tests cover env detection, schema validity, tracing block, provider registry)
- [ ] `uv run pytest test/` — full existing suite passes
- [ ] Smoke: `cd /tmp/empty && planoai up` (no env keys) → proxy starts, prints `pass-through: openai, anthropic, gemini, groq, deepseek, mistral, do`
- [ ] Smoke: `export OPENAI_API_KEY=sk-...; planoai up` → prints `env-keyed: openai | pass-through: anthropic, ...`
- [ ] Smoke: `curl localhost:12000/v1/chat/completions -H "Authorization: Bearer \$KEY" -d '{"model":"openai/gpt-4o-mini","messages":[...]}'` succeeds end-to-end