### PR TITLE
fix: prevent index-out-of-bounds panic in signal analyzer follow-up

### DIFF
--- a/crates/brightstaff/src/signals/analyzer.rs
+++ b/crates/brightstaff/src/signals/analyzer.rs
@@ -1250,7 +1250,7 @@ impl TextBasedSignalAnalyzer {
         let mut repair_phrases = Vec::new();
         let mut user_turn_count = 0;
 
-        for (i, role, norm_msg) in normalized_messages {
+        for (pos, (i, role, norm_msg)) in normalized_messages.iter().enumerate() {
             if *role != Role::User {
                 continue;
             }
@@ -1274,10 +1274,13 @@ impl TextBasedSignalAnalyzer {
                 }
             }
 
-            // Only check for semantic similarity if no pattern matched
-            if !found_in_turn && *i >= 2 {
-                // Find previous user message
-                for j in (0..*i).rev() {
+            // Only check for semantic similarity if no pattern matched. Walk
+            // backwards through the *normalized* list (not the original
+            // conversation indices, which may be non-contiguous because
+            // messages without extractable text are filtered out) to find the
+            // most recent prior user message.
+            if !found_in_turn && pos >= 1 {
+                for j in (0..pos).rev() {
                     let (_, prev_role, prev_norm_msg) = &normalized_messages[j];
                     if *prev_role == Role::User {
                         if self.is_similar_rephrase(norm_msg, prev_norm_msg) {
@@ -2197,6 +2200,68 @@ mod tests {
         assert_eq!(signal.repair_count, 1);
         assert!(signal.repair_ratio > 0.0);
         println!("test_follow_up_detection took: {:?}", start.elapsed());
+    }
+
+    #[test]
+    fn test_follow_up_does_not_panic_with_filtered_messages() {
+        // Regression test: the preprocessing pipeline filters out messages
+        // without extractable text (tool calls, tool results, empty content).
+        // The stored tuple index `i` is the ORIGINAL-conversation index, so
+        // once anything is filtered out, `i` no longer matches the position
+        // inside `normalized_messages`. The old code used `*i` to index into
+        // `normalized_messages`, which panicked with "index out of bounds"
+        // when a user message appeared after filtered entries.
+        let analyzer = TextBasedSignalAnalyzer::new();
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: Some(hermesllm::apis::openai::MessageContent::Text(
+                    "first question".to_string(),
+                )),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            // Assistant message with no text content (e.g. tool call) — filtered out.
+            Message {
+                role: Role::Assistant,
+                content: None,
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            // Tool-role message with no extractable text — filtered out.
+            Message {
+                role: Role::Tool,
+                content: None,
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: Some(hermesllm::apis::openai::MessageContent::Text(
+                    "some answer".to_string(),
+                )),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            // Rephrased user turn — original index 4, but after filtering
+            // only 3 messages remain in `normalized_messages` before it.
+            Message {
+                role: Role::User,
+                content: Some(hermesllm::apis::openai::MessageContent::Text(
+                    "first question please".to_string(),
+                )),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        ];
+
+        // Must not panic — exercises the full analyze pipeline.
+        let _report = analyzer.analyze(&messages);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix an `index out of bounds` panic in `TextBasedSignalAnalyzer::analyze_follow_up` that fires whenever a conversation contains messages without extractable text (tool calls, tool results, Anthropic `<tool_use_error>` blocks, etc.) before a user turn.
- Switch the inner lookup to use the normalized-list position rather than the stored original-conversation index.
- Add a regression test that reproduces the exact panic shape through the public `analyze` entry point.

## Context

Seen in production logs:

```
thread 'tokio-rt-worker' (224527) panicked at brightstaff/src/signals/analyzer.rs:1281:58:
index out of bounds: the len is 15 but the index is 15
...latest_message=<tool_use_error>InputValidationError: Read failed ...
[info] no route determined, using default model

thread 'tokio-rt-worker' (224512) panicked at brightstaff/src/signals/analyzer.rs:1281:58:
index out of bounds: the len is 16 but the index is 17
```

### Root cause

`TextBasedSignalAnalyzer::analyze` preprocesses messages like this:

```rust
let normalized_messages: Vec<(usize, Role, NormalizedMessage)> = messages_to_process
    .iter()
    .enumerate()
    .filter_map(|(i, msg)| {
        Self::extract_text(&msg.content).map(|text| {
            (i, msg.role.clone(), NormalizedMessage::from_text_with_limit(&text, self.max_message_length))
        })
    })
    .collect();
```

The stored `i` is the **original** conversation index, but `filter_map` drops any message whose content is not plain text (`extract_text` returns `None` for tool calls, tool results, `None` content). So `normalized_messages.len()` can be strictly less than the largest stored `i`.

`analyze_follow_up` then used that stored `i` to look back:

```rust
if !found_in_turn && *i >= 2 {
    for j in (0..*i).rev() {
        let (_, prev_role, prev_norm_msg) = &normalized_messages[j]; // PANIC
        ...
    }
}
```

The moment any message gets filtered out before the current user turn, `*i` exceeds the normalized-list length and this line panics.

### Impact

- Not catastrophic to request serving: the panic is caught at the tokio task boundary and the request continues with `no route determined, using default model`. Default unwind panic strategy (`panic = "unwind"`, the cargo default) keeps the worker thread alive.
- **Routing quality:** signal analysis is silently skipped for every affected request, so `follow_up`/`repetition`/etc. signals are missing and routing decisions may be degraded.
- **Operational noise:** every affected request produces a scary multi-line panic stack trace in logs, making real issues harder to spot.

## Fix

Walk `normalized_messages` with an outer `iter().enumerate()` and use that **position** for the inner reverse scan, instead of the stored original-conversation index. The stored `i` stays only for display (`"Turn N"` strings).

```rust
for (pos, (i, role, norm_msg)) in normalized_messages.iter().enumerate() {
    ...
    if !found_in_turn && pos >= 1 {
        for j in (0..pos).rev() {
            let (_, prev_role, prev_norm_msg) = &normalized_messages[j];
            ...
        }
    }
}
```

I also audited the rest of `analyzer.rs` — line 1281 was the **only** place that indexed `normalized_messages` with the stored `i`; other analyzers only use it in display strings.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` clean.
- [x] `cargo test --lib` — all workspace tests pass.
- [x] New regression test `test_follow_up_does_not_panic_with_filtered_messages` exercises the public `analyze` entry point with a realistic conversation shape (user → assistant-tool-call → tool-result → assistant-text → rephrased-user) that reliably panicked without the fix.

Made with [Cursor](https://cursor.com)