### PR TITLE
Add claude-opus-4-7 to anthropic provider models

### DIFF
--- a/crates/hermesllm/src/bin/provider_models.yaml
+++ b/crates/hermesllm/src/bin/provider_models.yaml
@@ -95,6 +95,7 @@ providers:
   anthropic:
   - anthropic/claude-sonnet-4-6
   - anthropic/claude-opus-4-6
+  - anthropic/claude-opus-4-7
   - anthropic/claude-opus-4-5-20251101
   - anthropic/claude-opus-4-5
   - anthropic/claude-haiku-4-5-20251001


### PR DESCRIPTION
## Summary

Register `anthropic/claude-opus-4-7` in `crates/hermesllm/src/bin/provider_models.yaml` so routing and cost lookups recognize the new Opus 4.7 model alongside the existing 4.5 / 4.6 entries.

## Test plan

- [ ] Confirm requests for `claude-opus-4-7` are routed correctly through the Anthropic provider
- [ ] `cd crates && cargo test --lib` passes